### PR TITLE
Proper target release display in fleet

### DIFF
--- a/src/components/fleet.js
+++ b/src/components/fleet.js
@@ -60,7 +60,7 @@ export const FleetList = props => {
                 </ReferenceField>
                 <BooleanBinaryField label="Track Latest Rel." source="should track latest release"/>
                 <ReferenceField label="Target Rel." source="should be running-release" reference="release" target="id">
-                    <ChipField source="revision"/>
+                    <ChipField source="id"/>
                 </ReferenceField>
                 <SelectField label="Class" source="is of-class" choices={[
                     { id: "fleet", name: "Fleet" },


### PR DESCRIPTION
`revision` is not a reliable way to reference a `Release`. It is only increased when two releases with the same version are deployed. `id` is a better way to uniquely reference a `Release` since it is also presented in the release.js component.