### PR TITLE
Change 'should be running-release' with 'is pinned on-release' for openbalena v4

### DIFF
--- a/src/components/device.js
+++ b/src/components/device.js
@@ -178,7 +178,7 @@ export const DeviceCreate = (props) => {
               formData['belongs to-application'] && (
                 <ReferenceInput
                   label='Target Release'
-                  source='should be running-release'
+                  source='is pinned on-release'
                   reference='release'
                   target='id'
                   filter={{ 'belongs to-application': formData['belongs to-application'] }}
@@ -252,7 +252,7 @@ export const DeviceEdit = () => {
               formData['belongs to-application'] && (
                 <ReferenceInput
                   label='Target Release'
-                  source='should be running-release'
+                  source='is pinned on-release'
                   reference='release'
                   target='id'
                   filter={{ 'belongs to-application': formData['belongs to-application'] }}

--- a/src/components/fleet.js
+++ b/src/components/fleet.js
@@ -74,7 +74,7 @@ export const FleetList = () => {
           <TextField source='slug' />
         </ReferenceField>
 
-        <ReferenceField label='Target Rel.' source='should be running-release' reference='release' target='id'>
+        <ReferenceField label='Target Rel.' source='is pinned on-release' reference='release' target='id'>
           <SemVerChip />
         </ReferenceField>
 
@@ -306,7 +306,7 @@ export const FleetEdit = () => {
               formData['should track latest release'] === 0 && (
                 <ReferenceInput
                   label='Target Release'
-                  source='should be running-release'
+                  source='is pinned on-release'
                   reference='release'
                   target='id'
                   filter={{ 'belongs to-application': fleetId }}
@@ -334,3 +334,4 @@ const fleet = {
 };
 
 export default fleet;
+d

--- a/src/dashboards/device/summary.js
+++ b/src/dashboards/device/summary.js
@@ -116,7 +116,7 @@ const Summary = () => {
 
                   <td>
                     <Label>Target Release</Label>
-                    <ReferenceField source='should be running-release' reference='release' target='id'>
+                    <ReferenceField source='is pinned on-release' reference='release' target='id'>
                       <SemVerChip />
                     </ReferenceField>
                   </td>

--- a/src/dashboards/main/fleets.js
+++ b/src/dashboards/main/fleets.js
@@ -122,7 +122,7 @@ export const FleetCards = () => (
                                 <ReferenceField
                                   record={record}
                                   label='Target Rel.'
-                                  source='should be running-release'
+                                  source='is pinned on-release'
                                   reference='release'
                                   target='id'
                                 >

--- a/src/ui/DeleteReleaseButton.js
+++ b/src/ui/DeleteReleaseButton.js
@@ -28,8 +28,8 @@ export const DeleteReleaseButton = ({ selectedIds, context, ...props }) => {
   React.useEffect(() => {
     const canDeleteRelease = async (releaseId) => {
       let releaseLookups = [
-        { resource: 'device', field: '#is running-release,should be running-release,should be operated by-release@eq' },
-        { resource: 'application', field: 'should be running-release' },
+        { resource: 'device', field: '#is running-release,is pinned on-release,should be operated by-release@eq' },
+        { resource: 'application', field: 'is pinned on-release' },
       ];
       let count = 0;
       await Promise.all(


### PR DESCRIPTION
The team at balena seems to have changed the column name of the db from should be running-release too is pinned on-release. Which seems to be their new way to address it [as seen here](https://github.com/balena-io/balena-cli/commit/19be0fec1a99ae0076abc65cf40fb8c8168af734)

This will disable functionality with older versions of openbalena