### PR TITLE
fix: CI/CD Github Action with auto versioning & push to Docker Hub

### DIFF
--- a/.vscode/workflows/ci.yml
+++ b/.vscode/workflows/ci.yml
@@ -1,0 +1,126 @@
+name: CI
+
+on:
+  # Do not build 3rd party package updates automatically to avoid some hacked package stealing secrets https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+  push:
+    branches-ignore:
+      - 'renovate/3rd-party**'
+      - 'dependabot/**'
+  pull_request:
+    branches-ignore:
+      - 'renovate/3rd-party**'
+      - 'dependabot/**'
+
+env:
+  IMAGE_NAME: harmonidcaputo/open-balena-ui
+  BASE_VERSION: '0.1.0' # Where action-vtl starts if there are no existing tags
+  NODE_VERSION: 20 # Match the Dockerfile version
+
+jobs:
+  # Sanity checks: Lint, test, and build the project
+  build-test:
+    name: Lint, Test, and Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Establish Versioning, Tags, and Labels
+        id: vtl
+        uses: mapped/action-vtl@latest
+        with:
+          baseVersion: ${{ env.BASE_VERSION }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Project dependencies
+        run: npm ci
+
+      - name: Linting
+        if: false # ESLint needs added to dev-dependencies and configured properly...
+        run: npm run lint
+
+      - name: Testing
+        if: false # Jest (or similar) needs added to dev-dependencies and configured properly...
+        run: npm run test
+
+      - name: Build
+        run: npm run build
+
+  # Build the docker container in all branches (without pushing)
+  build-docker:
+    name: Build for docker
+    runs-on: ubuntu-latest
+    needs: build-test
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Establish Versioning, Tags, and Labels
+        id: vtl
+        uses: mapped/action-vtl@latest
+        with:
+          baseVersion: ${{ env.BASE_VERSION }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          dockerImage: ${{ env.IMAGE_NAME }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          provenance: false
+          file: ./Dockerfile
+          push: false
+          tags: ${{ steps.vtl.outputs.docker_dtag }}
+          labels: ${{ steps.vtl.outputs.oci_labels }}
+
+  # Build and push the docker container to Docker Hub for everything **except PRs**
+  # main gets "latest" tag, all other branches get branch name tag and "prerelease" in the version
+  # see: https://github.com/mapped/action-vtl?tab=readme-ov-file#docker-tags
+  push-to-docker-hub:
+    name: Push to Docker Hub
+    runs-on: ubuntu-latest
+    needs: build-docker
+    if: ${{ !startsWith(github.ref, 'refs/pull/') }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Establish Versioning, Tags, and Labels
+        id: vtl
+        uses: mapped/action-vtl@latest
+        with:
+          baseVersion: ${{ env.BASE_VERSION }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          dockerImage: ${{ env.IMAGE_NAME }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          provenance: false
+          file: ./Dockerfile
+          push: ${{ steps.vtl.outputs.docker_push }}
+          tags: ${{ steps.vtl.outputs.docker_dtag }}
+          labels: ${{ steps.vtl.outputs.oci_labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM debian:bullseye
+FROM debian:bookworm
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Update nodejs version to 17.x
+# Update nodejs version to 20.x
 RUN apt-get update && apt-get install -y curl && \
-    curl -sL https://deb.nodesource.com/setup_17.x | bash -
+    curl -sL https://deb.nodesource.com/setup_20.x | bash -
 
 RUN apt-get update && apt-get install -y \
     nodejs \
@@ -20,7 +20,7 @@ COPY ./webpack.config.js ./
 COPY ./package.json ./
 COPY ./package-lock.json ./
 
-RUN npm install --no-fund --no-update-notifier
+RUN npm ci --no-fund --no-update-notifier
 
 COPY start.sh ./
 


### PR DESCRIPTION
**Also updating node to LTS v20 and Debian to LTS v12 (bookworm)**

...

The CI/CD Action script requires a `DOCKERHUB_USERNAME` repo variable set and a `DOCKERHUB_TOKEN` repo secret set. They can be set at https://github.com/dcaputo-harmoni/open-balena-ui/settings/variables/actions and https://github.com/dcaputo-harmoni/open-balena-ui/settings/secrets/actions

`build-test` and `build-docker` will run on pushes to **all** branches and PRs, `push-to-docker-hub` will only run on local branches (creating versioned, prerelease, and latest tags as appropriate). This means that the DOCKERHUB_TOKEN only gets used if you're pushing to your own branches or **accept** someone's PR, not when people work on branches in their forks or push a PR, but you get to at least see that their PR passes lint/test/build/docker build (once lint and test are added 😅). Lots of detail and examples at https://github.com/mapped/action-vtl

Really important note: action-vtl increments version numbers via semantic commit messaging, as described at https://github.com/mapped/action-vtl?tab=readme-ov-file#version-automatic-increment

... also worth noting that I think I got all this right, but GitHub won't run actions in branches/PRs until they are merged to main 😅. Once all is good on this repo, I can push similar PRs for the other open-balena repos (builder, helper, remote, postgrest, delta).