### PR TITLE
fix: gui merge cleanup and tooltip improvements

### DIFF
--- a/src/components/device.js
+++ b/src/components/device.js
@@ -76,9 +76,9 @@ export const ReleaseField = (props) => {
         if (isPending) { return <p>Loading</p>; }
         if (error) { return <p>ERROR</p>; }
 
-        const currentRelease = record[source];
-        const targetRelease = record['{isPinnedOnRelease}'] || fleet['{isPinnedOnRelease}'];
-        const isUpToDate = !!(currentRelease && currentRelease === targetRelease);
+        record['should be running-release'] = record['{isPinnedOnRelease}'] || fleet['should be running-release'];
+
+        const isUpToDate = !!(record[source] && record[source] === record['should be running-release']);
         const isOnline = record['api heartbeat state'] === 'online';
         return (
           <>

--- a/src/components/device.js
+++ b/src/components/device.js
@@ -35,6 +35,7 @@ import DeviceServicesButton from '../ui/DeviceServicesButton';
 import Row from '../ui/Row';
 import SelectOperatingSystem from '../ui/SelectOperatingSystem';
 import SemVerChip, { getSemver } from '../ui/SemVerChip';
+import SemVerTextField from '../ui/SemVerTextField';
 import versions from '../versions';
 import environment from '../lib/reactAppEnv';
 
@@ -80,30 +81,41 @@ export const ReleaseField = (props) => {
 
         const isUpToDate = !!(record[source] && record[source] === record['should be running-release']);
         const isOnline = record['api heartbeat state'] === 'online';
+
         return (
           <>
             <ReferenceField label='Current Release' source='is running-release' reference='release' target='id'>
               <SemVerChip sx={{ position: 'relative', top: '-5px' }} />
             </ReferenceField>
 
-            <Tooltip
-              placement='top'
-              arrow={true}
-              title={'Target Release: ' + (targetRelease || 'n/a')}
-            >
-              <span style={{
-                position: 'relative',
-                top: '3px',
-                left: '3px',
-                color: (!isUpToDate && isOnline) ? theme.palette.error.light : theme.palette.text.primary
-              }}>
-                {
-                  isUpToDate ? <Done /> :
-                  isOnline ? <Warning /> :
-                  <WarningAmber />
+            {
+              record[source] &&
+              <Tooltip
+                placement='top'
+                arrow={true}
+                title={
+                  <>
+                    Target Release:
+                    <ReferenceField reference='release' target='id' source='should be running-release'>
+                      <SemVerTextField style={{marginLeft: '3px', fontSize: '0.7rem'}} />
+                    </ReferenceField>
+                  </>
                 }
-              </span>
-            </Tooltip>
+              >
+                <span style={{
+                  position: 'relative',
+                  top: '3px',
+                  left: '3px',
+                  color: (!isUpToDate && isOnline) ? theme.palette.error.light : theme.palette.text.primary
+                }}>
+                  {
+                    isUpToDate ? <Done /> :
+                    isOnline ? <Warning /> :
+                    <WarningAmber />
+                  }
+                </span>
+              </Tooltip>
+            }
           </>
         );
       }}

--- a/src/components/fleet.js
+++ b/src/components/fleet.js
@@ -28,10 +28,6 @@ import { useCreateFleet } from '../lib/fleet';
 import DeleteFleetButton from '../ui/DeleteFleetButton';
 import Row from '../ui/Row';
 import SemVerChip, { getSemver } from '../ui/SemVerChip';
-import versions from '../versions';
-import environment from '../lib/reactAppEnv';
-
-const isPinnedOnRelease = versions.resource('isPinnedOnRelease', environment.REACT_APP_OPEN_BALENA_API_VERSION);
 
 const CustomBulkActionButtons = (props) => (
   <React.Fragment>
@@ -300,7 +296,7 @@ export const FleetEdit = () => {
             !formData['should track latest release'] && (
               <ReferenceInput
                 label='Target Release'
-                source={isPinnedOnRelease}
+                source='should be running-release'
                 reference='release'
                 target='id'
                 filter={{ 'belongs to-application': fleetId }}

--- a/src/dashboards/device/usageWidget.js
+++ b/src/dashboards/device/usageWidget.js
@@ -32,7 +32,7 @@ const UsageWidget = () => {
             label='Temp'
             value={isFinite(record['cpu temp']) ? (record['cpu temp'] / 90) * 100 : 0}
             displayValue={isFinite(record['cpu temp']) ? record['cpu temp'] : 0}
-            displayUnits='&#x2103;'
+            displayUnits='&deg;C'
           />
         </div>
 

--- a/src/dashboards/device/usageWidget.js
+++ b/src/dashboards/device/usageWidget.js
@@ -1,4 +1,4 @@
-import { Box, LinearProgress } from '@mui/material';
+import { Box, LinearProgress, Tooltip } from '@mui/material';
 import * as React from 'react';
 import { useRecordContext } from 'react-admin';
 
@@ -10,7 +10,9 @@ const LinearProgressWithLabel = (props) => {
         <LinearProgress variant='determinate' color='secondary' {...props} />
       </Box>
       <Box sx={{ flex: 1, minWidth: '3em' }}>
-        {props.displayValue ? props.displayValue + props.displayUnits : Math.round(props.value) + '%'}
+        <Tooltip placement='top' arrow={true} title={props.tooltip}>
+          {props.displayValue ? props.displayValue + props.displayUnits : Math.round(props.value) + '%'}
+        </Tooltip>
       </Box>
     </Box>
   );
@@ -44,6 +46,11 @@ const UsageWidget = () => {
                 ? (record['storage usage'] / record['storage total']) * 100
                 : 0
             }
+            tooltip={
+              isFinite(record['storage usage'] / record['storage total'])
+                ? `Usage: ${record['storage usage']} MB of ${record['storage total']} MB`
+                : ''
+            }
           />
 
           <LinearProgressWithLabel
@@ -54,6 +61,11 @@ const UsageWidget = () => {
                 ? (record['memory usage'] / record['memory total']) * 100
                 : 0
             }
+            tooltip={
+              isFinite(record['memory usage'] / record['memory total'])
+                ? `Usage: ${record['memory usage']} MB of ${record['memory total']} MB`
+                : ''
+          }
           />
         </div>
       </Box>


### PR DESCRIPTION
Fixes #30 #32 #33.

Small improvements:
+ adding "actual value tooltips to `memory usage` and `storage usage` in device usageWidget. 
+ replacing `release id`  with `semver` in tooltip of current release icon tooltip.