### PR TITLE
Add structured device filtering to device list

### DIFF
--- a/src/ui/ActiveFilterChips.tsx
+++ b/src/ui/ActiveFilterChips.tsx
@@ -1,0 +1,227 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Chip } from '@mui/material';
+import { useDataProvider } from 'react-admin';
+import type { DataProvider } from 'react-admin';
+import type { ResourceRecord } from '../types/resource';
+import type { DeviceFilterState, OnlineStatus } from './DeviceFilterModal';
+import { getSemver } from './SemVerChip';
+
+interface ActiveFilterChipsProps {
+  filters: DeviceFilterState;
+  onRemoveFilter: (filterKey: keyof DeviceFilterState) => void;
+}
+
+interface ResolvedLabels {
+  deviceTypeName: string | null;
+  fleetName: string | null;
+  releaseLabels: string[];
+}
+
+export const ActiveFilterChips: React.FC<ActiveFilterChipsProps> = ({
+  filters,
+  onRemoveFilter,
+}) => {
+  const dataProvider = useDataProvider<DataProvider>();
+  const [labels, setLabels] = useState<ResolvedLabels>({
+    deviceTypeName: null,
+    fleetName: null,
+    releaseLabels: [],
+  });
+
+  const getNonNullReleaseIds = (ids: Array<number | null>): number[] =>
+    ids.filter((id): id is number => id !== null);
+
+  // Resolve IDs to human-readable names
+  useEffect(() => {
+    let cancelled = false;
+
+    const resolveLabels = async () => {
+      const newLabels: ResolvedLabels = {
+        deviceTypeName: null,
+        fleetName: null,
+        releaseLabels: [],
+      };
+
+      const releaseIds = getNonNullReleaseIds(filters.releaseIds);
+
+      // Short-circuit if there are no ID-based filters
+      if (!filters.deviceTypeId && !filters.fleetId && releaseIds.length === 0) {
+        if (!cancelled) {
+          setLabels(newLabels);
+        }
+        return;
+      }
+
+      try {
+        const [deviceTypeResp, fleetResp, releasesResp] = await Promise.all([
+          filters.deviceTypeId
+            ? dataProvider.getOne<ResourceRecord>('device type', {
+                id: filters.deviceTypeId,
+              })
+            : Promise.resolve(null),
+          filters.fleetId
+            ? dataProvider.getOne<ResourceRecord>('application', {
+                id: filters.fleetId,
+              })
+            : Promise.resolve(null),
+          releaseIds.length > 0
+            ? dataProvider.getMany<ResourceRecord>('release', {
+                ids: releaseIds,
+              })
+            : Promise.resolve(null),
+        ]);
+
+        if (deviceTypeResp) {
+          newLabels.deviceTypeName = deviceTypeResp.data.slug as string;
+        } else if (filters.deviceTypeId) {
+          newLabels.deviceTypeName = `ID: ${filters.deviceTypeId}`;
+        }
+
+        if (fleetResp) {
+          newLabels.fleetName = fleetResp.data['app name'] as string;
+        } else if (filters.fleetId) {
+          newLabels.fleetName = `ID: ${filters.fleetId}`;
+        }
+
+        if (releasesResp) {
+          newLabels.releaseLabels = releasesResp.data.map((release) => getSemver(release));
+        } else if (releaseIds.length > 0) {
+          newLabels.releaseLabels = releaseIds.map((id) => `ID: ${id}`);
+        }
+      } catch {
+        // On error, fall back to raw IDs
+        if (filters.deviceTypeId) {
+          newLabels.deviceTypeName = `ID: ${filters.deviceTypeId}`;
+        }
+        if (filters.fleetId) {
+          newLabels.fleetName = `ID: ${filters.fleetId}`;
+        }
+        const releaseIds = getNonNullReleaseIds(filters.releaseIds);
+        if (releaseIds.length > 0) {
+          newLabels.releaseLabels = releaseIds.map((id) => `ID: ${id}`);
+        }
+      }
+
+      if (!cancelled) {
+        setLabels(newLabels);
+      }
+    };
+
+    void resolveLabels();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [dataProvider, filters.deviceTypeId, filters.fleetId, filters.releaseIds]);
+
+  // Check if there are any active filters
+  const nonNullReleaseIds = getNonNullReleaseIds(filters.releaseIds);
+  const hasActiveFilters =
+    filters.onlineStatus !== 'all' ||
+    filters.deviceTypeId !== null ||
+    filters.fleetId !== null ||
+    nonNullReleaseIds.length > 0 ||
+    filters.osVersion !== '';
+
+  if (!hasActiveFilters) {
+    return null;
+  }
+
+  const getStatusLabel = (status: OnlineStatus): string => {
+    switch (status) {
+      case 'online':
+        return 'Online';
+      case 'offline':
+        return 'Offline';
+      default:
+        return '';
+    }
+  };
+
+  const getReleaseChipLabel = (): string => {
+    const releaseIds = getNonNullReleaseIds(filters.releaseIds);
+
+    if (releaseIds.length === 0) {
+      return '';
+    }
+    if (releaseIds.length === 1) {
+      return labels.releaseLabels[0] || 'Loading...';
+    }
+    return `${releaseIds.length} selected`;
+  };
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: 1,
+        py: 0,
+        px: 0,
+      }}
+    >
+      {/* Online Status Chip */}
+      {filters.onlineStatus !== 'all' && (
+        <Chip
+          label={`Status: ${getStatusLabel(filters.onlineStatus)}`}
+          onDelete={() => onRemoveFilter('onlineStatus')}
+          size='small'
+          color='primary'
+          variant='outlined'
+          sx={{ maxWidth: '180px' }}
+        />
+      )}
+
+      {/* Device Type Chip */}
+      {filters.deviceTypeId !== null && (
+        <Chip
+          label={`Type: ${labels.deviceTypeName || 'Loading...'}`}
+          onDelete={() => onRemoveFilter('deviceTypeId')}
+          size='small'
+          color='primary'
+          variant='outlined'
+          sx={{ maxWidth: '180px' }}
+        />
+      )}
+
+      {/* Fleet Chip */}
+      {filters.fleetId !== null && (
+        <Chip
+          label={`Fleet: ${labels.fleetName || 'Loading...'}`}
+          onDelete={() => onRemoveFilter('fleetId')}
+          size='small'
+          color='primary'
+          variant='outlined'
+          sx={{ maxWidth: '180px' }}
+        />
+      )}
+
+      {/* Release Chip */}
+      {nonNullReleaseIds.length > 0 && (
+        <Chip
+          label={`Release: ${getReleaseChipLabel()}`}
+          onDelete={() => onRemoveFilter('releaseIds')}
+          size='small'
+          color='primary'
+          variant='outlined'
+          sx={{ maxWidth: '180px' }}
+        />
+      )}
+
+      {/* OS Version Chip */}
+      {filters.osVersion !== '' && (
+        <Chip
+          label={`OS: ${filters.osVersion}`}
+          onDelete={() => onRemoveFilter('osVersion')}
+          size='small'
+          color='primary'
+          variant='outlined'
+          sx={{ maxWidth: '180px' }}
+        />
+      )}
+    </Box>
+  );
+};
+
+export default ActiveFilterChips;
+

--- a/src/ui/DeviceFilterModal.tsx
+++ b/src/ui/DeviceFilterModal.tsx
@@ -199,7 +199,6 @@ export const DeviceFilterModal: React.FC<DeviceFilterModalProps> = ({
   // Fetch releases with pagination (cached by react-query)
   const {
     data: releasesData,
-    isLoading: releasesLoading,
     isFetching: releasesFetching,
     total: releasesTotal,
   } = useGetList(

--- a/src/ui/DeviceFilterModal.tsx
+++ b/src/ui/DeviceFilterModal.tsx
@@ -1,0 +1,677 @@
+import React, { useEffect, useState, useMemo } from 'react';
+import {
+  Autocomplete,
+  Box,
+  Button,
+  Checkbox,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  ListItemText,
+  MenuItem,
+  Radio,
+  RadioGroup,
+  Select,
+  TextField,
+  Typography,
+  CircularProgress,
+} from '@mui/material';
+import type { SelectChangeEvent } from '@mui/material';
+import { useGetList } from 'react-admin';
+import { getSemver } from './SemVerChip';
+
+export type OnlineStatus = 'all' | 'online' | 'offline';
+
+export interface DeviceFilterState {
+  onlineStatus: OnlineStatus;
+  deviceTypeId: number | null;
+  fleetId: number | null;
+  // May contain a special `null` sentinel value to represent that the user
+  // explicitly chose "Select None" for releases.
+  releaseIds: Array<number | null>;
+  osVersion: string;
+}
+
+export const defaultFilterState: DeviceFilterState = {
+  onlineStatus: 'all',
+  deviceTypeId: null,
+  fleetId: null,
+  releaseIds: [],
+  osVersion: '',
+};
+
+interface DeviceType {
+  id: number;
+  slug: string;
+}
+
+interface Fleet {
+  id: number;
+  'app name': string;
+  'is for-device type': number;
+}
+
+interface Release {
+  id: number;
+  'belongs to-application': number;
+  'semver major': number;
+  'semver minor': number;
+  'semver patch': number;
+  'semver prerelease': string;
+  'semver build': string;
+  'semver revision': number;
+  commit: string;
+  'created at': string;
+}
+
+export interface DeviceFilterModalProps {
+  open: boolean;
+  onClose: () => void;
+  onApply: (filters: DeviceFilterState) => void;
+  currentFilters: DeviceFilterState;
+}
+
+export const DeviceFilterModal: React.FC<DeviceFilterModalProps> = ({
+  open,
+  onClose,
+  onApply,
+  currentFilters,
+}) => {
+  // Local state for the modal form
+  const [localFilters, setLocalFilters] = useState<DeviceFilterState>(currentFilters);
+
+  const getNonNullReleaseIds = (ids: Array<number | null>): number[] =>
+    ids.filter((id): id is number => id !== null);
+
+  // Fetch device types using useGetList (cached by react-query)
+  const { data: deviceTypesData, isLoading: deviceTypesLoading } = useGetList(
+    'device type',
+    {
+      pagination: { page: 1, perPage: 1000 },
+      sort: { field: 'slug', order: 'ASC' },
+      filter: {},
+    },
+    { enabled: open }
+  );
+
+  const deviceTypes = useMemo<DeviceType[]>(
+    () =>
+      deviceTypesData?.map((dt) => ({
+        id: Number(dt.id),
+        slug: dt.slug as string,
+      })) ?? [],
+    [deviceTypesData]
+  );
+
+  // Search state for OS version typeahead
+  const [osVersionSearch, setOsVersionSearch] = useState('');
+  const [debouncedOsVersionSearch, setDebouncedOsVersionSearch] = useState('');
+
+  // Debounce the OS version search input
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedOsVersionSearch(osVersionSearch);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [osVersionSearch]);
+
+  // Only search when 3+ characters are entered
+  const shouldSearchOsVersions = debouncedOsVersionSearch.length >= 3;
+
+  // Fetch devices with OS version filter (cached by react-query)
+  const { data: devicesData, isLoading: devicesLoading } = useGetList(
+    'device',
+    {
+      pagination: { page: 1, perPage: 100 },
+      sort: { field: 'os version', order: 'ASC' },
+      filter: shouldSearchOsVersions ? { 'os version@ilike': debouncedOsVersionSearch } : {},
+    },
+    { enabled: open && shouldSearchOsVersions }
+  );
+
+  const osVersionOptions = useMemo<string[]>(() => {
+    if (!devicesData) return [];
+    const uniqueOsVersions = new Set<string>();
+    devicesData.forEach((device) => {
+      const osVersion = device['os version'] as string;
+      if (osVersion) {
+        uniqueOsVersions.add(osVersion);
+      }
+    });
+    return Array.from(uniqueOsVersions).sort();
+  }, [devicesData]);
+
+  // Fetch fleets based on selected device type (cached by react-query)
+  const fleetsFilter = useMemo(() => {
+    const filter: Record<string, unknown> = { 'is of-class': 'fleet' };
+    if (localFilters.deviceTypeId) {
+      filter['is for-device type'] = localFilters.deviceTypeId;
+    }
+    return filter;
+  }, [localFilters.deviceTypeId]);
+
+  const { data: fleetsData } = useGetList(
+    'application',
+    {
+      pagination: { page: 1, perPage: 1000 },
+      sort: { field: 'app name', order: 'ASC' },
+      filter: fleetsFilter,
+    },
+    { enabled: open }
+  );
+
+  const fleets = useMemo<Fleet[]>(
+    () =>
+      fleetsData?.map((fleet) => ({
+        id: Number(fleet.id),
+        'app name': fleet['app name'] as string,
+        'is for-device type': fleet['is for-device type'] as number,
+      })) ?? [],
+    [fleetsData]
+  );
+
+  // Build releases filter based on device type and fleet selection
+  const releasesFilter = useMemo(() => {
+    const filter: Record<string, unknown> = {};
+
+    if (localFilters.fleetId) {
+      filter['belongs to-application'] = localFilters.fleetId;
+    } else if (localFilters.deviceTypeId && fleets.length > 0) {
+      const relevantFleetIds = fleets
+        .filter((f) => f['is for-device type'] === localFilters.deviceTypeId)
+        .map((f) => f.id);
+      if (relevantFleetIds.length > 0) {
+        filter['belongs to-application@in'] = `(${relevantFleetIds.join(',')})`;
+      }
+    }
+
+    return filter;
+  }, [localFilters.fleetId, localFilters.deviceTypeId, fleets]);
+
+  // Pagination state for releases
+  const [releasesPage, setReleasesPage] = useState(1);
+  const [accumulatedReleases, setAccumulatedReleases] = useState<Release[]>([]);
+
+  // Fetch releases with pagination (cached by react-query)
+  const {
+    data: releasesData,
+    isLoading: releasesLoading,
+    isFetching: releasesFetching,
+    total: releasesTotal,
+  } = useGetList(
+    'release',
+    {
+      pagination: { page: releasesPage, perPage: 100 },
+      sort: { field: 'id', order: 'DESC' },
+      filter: releasesFilter,
+    },
+    { enabled: open }
+  );
+
+  // Track filter changes to reset pagination
+  const [prevReleasesFilter, setPrevReleasesFilter] = useState(releasesFilter);
+
+  // Reset page when filter changes
+  useEffect(() => {
+    if (releasesFilter !== prevReleasesFilter) {
+      setPrevReleasesFilter(releasesFilter);
+      setReleasesPage(1);
+      setAccumulatedReleases([]);
+    }
+  }, [releasesFilter, prevReleasesFilter]);
+
+  // Accumulate releases when data loads
+  useEffect(() => {
+    if (releasesData) {
+      const newReleases = releasesData.map((r) => ({ ...r, id: Number(r.id) }) as Release);
+      const newReleaseIds = newReleases.map((r) => r.id);
+
+      if (releasesPage === 1) {
+        // Replace all releases on page 1 (handles filter changes)
+        setAccumulatedReleases(newReleases);
+      } else {
+        // Append for subsequent pages (de-duplicated)
+        setAccumulatedReleases((prev) => {
+          const existingIds = new Set(prev.map((r) => r.id));
+          const deduped = newReleases.filter((r) => !existingIds.has(r.id));
+          return [...prev, ...deduped];
+        });
+        // Auto-select newly loaded releases (de-duplicated)
+        setLocalFilters((prev) => ({
+          ...prev,
+          releaseIds: Array.from(new Set([...prev.releaseIds, ...newReleaseIds])),
+        }));
+      }
+    }
+  }, [releasesData, releasesPage]);
+
+  // Use accumulated releases
+  const releases = accumulatedReleases;
+
+  // Check if there are more releases to load
+  const hasMoreReleases = releasesTotal !== undefined && accumulatedReleases.length < releasesTotal;
+
+  const handleLoadMoreReleases = () => {
+    setReleasesPage((p) => p + 1);
+  };
+
+  // Combined loading state
+  const isLoading = deviceTypesLoading;
+
+  // Sync local filters with current filters when modal opens
+  useEffect(() => {
+    if (open) {
+      setLocalFilters(currentFilters);
+      // Set OS version search to current filter value
+      setOsVersionSearch(currentFilters.osVersion);
+      setDebouncedOsVersionSearch(currentFilters.osVersion);
+      // Reset releases pagination
+      setReleasesPage(1);
+    }
+  }, [open, currentFilters]);
+
+  // Auto-select all releases when none are chosen and no release filter exists (unless a `null` sentinel is present).
+  useEffect(() => {
+    const hasNullSentinel = localFilters.releaseIds.includes(null);
+    const localNonNullIds = getNonNullReleaseIds(localFilters.releaseIds);
+    const currentNonNullIds = getNonNullReleaseIds(currentFilters.releaseIds);
+
+    if (
+      open &&
+      !hasNullSentinel &&
+      releases.length > 0 &&
+      localNonNullIds.length === 0 &&
+      currentNonNullIds.length === 0
+    ) {
+      setLocalFilters((prev) => ({
+        ...prev,
+        releaseIds: releases.map((r) => r.id),
+      }));
+    }
+  }, [
+    open,
+    releases,
+    localFilters.releaseIds,
+    currentFilters.releaseIds,
+  ]);
+
+  // Filter releases based on device type and fleet selection
+  const filteredReleases = useMemo(() => {
+    let filtered = releases;
+
+    if (localFilters.fleetId) {
+      filtered = filtered.filter((r) => r['belongs to-application'] === localFilters.fleetId);
+    } else if (localFilters.deviceTypeId) {
+      const relevantFleetIds = fleets
+        .filter((f) => f['is for-device type'] === localFilters.deviceTypeId)
+        .map((f) => f.id);
+      filtered = filtered.filter((r) => relevantFleetIds.includes(r['belongs to-application']));
+    }
+
+    return filtered;
+  }, [releases, fleets, localFilters.deviceTypeId, localFilters.fleetId]);
+
+  // If there are no releases available for the current device/fleet filter,
+  // drop any previously selected release IDs (but keep an explicit `null` sentinel, if present).
+  useEffect(() => {
+    const nonNullReleaseIds = getNonNullReleaseIds(localFilters.releaseIds);
+    if (open && filteredReleases.length === 0 && nonNullReleaseIds.length > 0) {
+      setLocalFilters((prev) => ({
+        ...prev,
+        releaseIds: prev.releaseIds.includes(null) ? [null] : [],
+      }));
+    }
+  }, [open, filteredReleases, localFilters.releaseIds]);
+
+  const releaseMatchesSelection = (
+    release: Release,
+    nextDeviceTypeId: number | null,
+    nextFleetId: number | null
+  ) => {
+    if (nextFleetId) {
+      return release['belongs to-application'] === nextFleetId;
+    }
+
+    if (nextDeviceTypeId) {
+      const relevantFleetIds = fleets
+        .filter((f) => f['is for-device type'] === nextDeviceTypeId)
+        .map((f) => f.id);
+      if (relevantFleetIds.length > 0) {
+        return relevantFleetIds.includes(release['belongs to-application']);
+      }
+    }
+
+    // No device/fleet filter => all releases are valid
+    return true;
+  };
+
+  // Handlers
+  const handleOnlineStatusChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setLocalFilters((prev) => ({
+      ...prev,
+      onlineStatus: event.target.value as OnlineStatus,
+    }));
+  };
+
+  const handleDeviceTypeChange = (event: SelectChangeEvent<number | ''>) => {
+    const value = event.target.value;
+    const nextDeviceTypeId = value === '' ? null : Number(value);
+
+    setLocalFilters((prev) => ({
+      ...prev,
+      deviceTypeId: nextDeviceTypeId,
+      fleetId: null, // Reset fleet when device type changes
+      // Keep only releases that still match the new device type (via its fleets)
+      releaseIds: getNonNullReleaseIds(prev.releaseIds).filter((id) => {
+        const found = accumulatedReleases.find((r) => r.id === id);
+        return found ? releaseMatchesSelection(found, nextDeviceTypeId, null) : false;
+      }),
+    }));
+  };
+
+  const handleFleetChange = (event: SelectChangeEvent<number | ''>) => {
+    const value = event.target.value;
+    const nextFleetId = value === '' ? null : Number(value);
+
+    setLocalFilters((prev) => ({
+      ...prev,
+      fleetId: nextFleetId,
+      // Keep only releases that still match the new fleet/deviceType
+      releaseIds: getNonNullReleaseIds(prev.releaseIds).filter((id) => {
+        const found = accumulatedReleases.find((r) => r.id === id);
+        return found ? releaseMatchesSelection(found, prev.deviceTypeId, nextFleetId) : false;
+      }),
+    }));
+  };
+
+  const handleReleaseToggle = (releaseId: number) => {
+    setLocalFilters((prev) => {
+      const currentIds = getNonNullReleaseIds(prev.releaseIds);
+      const isCurrentlySelected = currentIds.includes(releaseId);
+
+      const withoutId = currentIds.filter((id) => id !== releaseId);
+      const nextIds: Array<number | null> = isCurrentlySelected
+        ? withoutId.length === 0
+          ? [null] // Explicit "Select None" sentinel
+          : withoutId
+        : [...currentIds, releaseId];
+
+      return {
+        ...prev,
+        releaseIds: nextIds,
+      };
+    });
+  };
+
+  const handleSelectAllReleases = () => {
+    // Select all visible releases explicitly
+    setLocalFilters((prev) => ({
+      ...prev,
+      releaseIds: filteredReleases.map((r) => r.id),
+    }));
+  };
+
+  const handleSelectNoneReleases = () => {
+    // Clear all selections
+    setLocalFilters((prev) => ({
+      ...prev,
+      // A single `null` sentinel marks the explicit "Select None" choice
+      releaseIds: [null],
+    }));
+  };
+
+  const handleOsVersionChange = (_event: React.SyntheticEvent, value: string | null) => {
+    setLocalFilters((prev) => ({
+      ...prev,
+      osVersion: value ?? '',
+    }));
+  };
+
+  const handleOsVersionInputChange = (_event: React.SyntheticEvent, value: string) => {
+    setOsVersionSearch(value);
+    // Also update the filter value as user types (freeSolo mode)
+    setLocalFilters((prev) => ({
+      ...prev,
+      osVersion: value,
+    }));
+  };
+
+  const handleApply = () => {
+    const effectiveReleaseIds = getNonNullReleaseIds(localFilters.releaseIds);
+    // Start with a copy of local filters, but strip out any `null` sentinel so
+    // that we never propagate it into the actual list filters.
+    const filtersToApply: DeviceFilterState = {
+      ...localFilters,
+      releaseIds: effectiveReleaseIds,
+    };
+
+    // If all releases are selected, don't apply release filter (empty array = no filter)
+    if (
+      filteredReleases.length > 0 &&
+      filteredReleases.every((r) => effectiveReleaseIds.includes(r.id))
+    ) {
+      filtersToApply.releaseIds = [];
+    }
+    onApply(filtersToApply);
+    onClose();
+  };
+
+  const handleReset = () => {
+    setLocalFilters(defaultFilterState);
+    setOsVersionSearch('');
+    setDebouncedOsVersionSearch('');
+    setReleasesPage(1);
+    setAccumulatedReleases([]);
+  };
+
+  // Check if a release is selected
+  const isReleaseSelected = (releaseId: number) => {
+    const currentIds = getNonNullReleaseIds(localFilters.releaseIds);
+    return currentIds.includes(releaseId);
+  };
+
+  const allReleasesSelected =
+    filteredReleases.length > 0 &&
+    filteredReleases.every((r) => isReleaseSelected(r.id));
+
+  const noReleasesSelected = localFilters.releaseIds.includes(null);
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth='xs' fullWidth>
+      <DialogTitle>Filter Devices</DialogTitle>
+
+      <DialogContent>
+        {isLoading ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+            <CircularProgress />
+          </Box>
+        ) : (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, pt: 1 }}>
+            {/* Online Status */}
+            <FormControl fullWidth size='small'>
+              <InputLabel shrink sx={{ position: 'relative', transform: 'none', mb: 0.5 }}>
+                Online Status
+              </InputLabel>
+              <RadioGroup
+                row
+                value={localFilters.onlineStatus}
+                onChange={handleOnlineStatusChange}
+              >
+                <FormControlLabel value='all' control={<Radio size='small' />} label='All' />
+                <FormControlLabel value='online' control={<Radio size='small' />} label='Online' />
+                <FormControlLabel value='offline' control={<Radio size='small' />} label='Offline' />
+              </RadioGroup>
+            </FormControl>
+
+            {/* Device Type */}
+            <FormControl fullWidth size='small'>
+              <InputLabel id='device-type-label'>Device Type</InputLabel>
+              <Select
+                labelId='device-type-label'
+                value={localFilters.deviceTypeId ?? ''}
+                label='Device Type'
+                onChange={handleDeviceTypeChange}
+              >
+                <MenuItem value=''>
+                  <em>All Device Types</em>
+                </MenuItem>
+                {deviceTypes.map((dt) => (
+                  <MenuItem key={dt.id} value={dt.id}>
+                    {dt.slug}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            {/* Fleet */}
+            <FormControl fullWidth size='small'>
+              <InputLabel id='fleet-label'>Fleet</InputLabel>
+              <Select
+                labelId='fleet-label'
+                value={localFilters.fleetId ?? ''}
+                label='Fleet'
+                onChange={handleFleetChange}
+              >
+                <MenuItem value=''>
+                  <em>All Fleets</em>
+                </MenuItem>
+                {fleets.map((fleet) => (
+                  <MenuItem key={fleet.id} value={fleet.id}>
+                    {fleet['app name']}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            {/* Current Release */}
+            <FormControl fullWidth size='small'>
+              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 0.5 }}>
+                <InputLabel shrink sx={{ position: 'relative', transform: 'none', overflow: 'visible' }}>
+                  Running Release
+                </InputLabel>
+                <Box sx={{ display: 'flex', gap: 1 }}>
+                  <Button size='small' variant='outlined' onClick={handleSelectAllReleases} disabled={allReleasesSelected}>
+                    Select All
+                  </Button>
+                  <Button size='small' variant='outlined' onClick={handleSelectNoneReleases} disabled={noReleasesSelected}>
+                    Select None
+                  </Button>
+                </Box>
+              </Box>
+              <Box
+                sx={(theme) => ({
+                  height: 200,
+                  overflowY: 'scroll',
+                  border: '1px solid',
+                  borderColor: theme.palette.text.disabled,
+                  borderRadius: `${theme.shape.borderRadius}px`,
+                  mt: 1,
+                  p: 1,
+                  '&:hover': {
+                    borderColor: theme.palette.text.primary,
+                  },
+                })}
+              >
+                {filteredReleases.length === 0 ? (
+                  <Typography variant='body2' color='text.secondary' sx={{ p: 1 }}>
+                    {releasesFetching ? 'Loading releases...' : 'No releases available'}
+                  </Typography>
+                ) : (
+                  <>
+                    {filteredReleases.map((release) => (
+                      <FormControlLabel
+                        key={release.id}
+                        control={
+                          <Checkbox
+                            checked={isReleaseSelected(release.id)}
+                            onChange={() => handleReleaseToggle(release.id)}
+                            size='small'
+                          />
+                        }
+                        label={
+                          <ListItemText
+                            primary={getSemver(release)}
+                            secondary={release['created at'] ? 'Released on ' + new Date(release['created at']).toLocaleDateString() : ''}
+                          />
+                        }
+                        sx={{ display: 'flex', width: '100%', m: 0 }}
+                      />
+                    ))}
+                    {hasMoreReleases && (
+                      <Button
+                        fullWidth
+                        size='small'
+                        onClick={handleLoadMoreReleases}
+                        disabled={releasesFetching}
+                        sx={{ my: 1 }}
+                        variant='outlined'
+                      >
+                        {releasesFetching
+                          ? 'Loading...'
+                          : `Load More (${accumulatedReleases.length} of ${releasesTotal})`}
+                      </Button>
+                    )}
+                  </>
+                )}
+              </Box>
+            </FormControl>
+
+            {/* Operating System */}
+            <Autocomplete
+              freeSolo
+              size='medium'
+              options={osVersionOptions}
+              value={localFilters.osVersion}
+              onChange={handleOsVersionChange}
+              onInputChange={handleOsVersionInputChange}
+              inputValue={osVersionSearch}
+              loading={devicesLoading}
+              noOptionsText={
+                osVersionSearch.length < 3
+                  ? 'Type at least 3 characters to search'
+                  : 'No OS versions found'
+              }
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  label='Operating System'
+                  placeholder='Search OS versions...'
+                  InputLabelProps={{ sx: { overflow: 'visible' } }}
+                  InputProps={{
+                    ...params.InputProps,
+                    endAdornment: (
+                      <>
+                        {devicesLoading ? <CircularProgress color='inherit' size={20} /> : null}
+                        {params.InputProps.endAdornment}
+                      </>
+                    ),
+                  }}
+                />
+              )}
+            />
+          </Box>
+        )}
+      </DialogContent>
+
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={handleReset} color='inherit' size='medium'>
+          Reset
+        </Button>
+        <Box sx={{ flex: 1 }} />
+        <Button onClick={onClose} variant='outlined' size='medium'>
+          Cancel
+        </Button>
+        <Button onClick={handleApply} variant='contained' size='medium'>
+          Apply Filters
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default DeviceFilterModal;
+

--- a/src/ui/DeviceStructuredFilter.tsx
+++ b/src/ui/DeviceStructuredFilter.tsx
@@ -1,0 +1,205 @@
+import { Box, Button } from '@mui/material';
+import { ManageSearch } from '@mui/icons-material';
+import * as React from 'react';
+import { useListContext } from 'react-admin';
+import DeviceFilterModal, { DeviceFilterState } from './DeviceFilterModal';
+import ActiveFilterChips from './ActiveFilterChips';
+
+// Custom filter button component
+const DeviceFilterButton: React.FC<{
+  onClick: () => void;
+  hasActiveFilters: boolean;
+}> = ({ onClick, hasActiveFilters }) => {
+  return (
+    <Button
+      variant='outlined'
+      size='small'
+      startIcon={<ManageSearch />}
+      onClick={onClick}
+      color={hasActiveFilters ? 'primary' : 'inherit'}
+      sx={{ ml: 1 }}
+    >
+      Filter
+    </Button>
+  );
+};
+
+// Helper to safely coerce potentially string IDs into numbers
+const toOptionalNumber = (value: unknown): number | null => {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+  const n = Number(value);
+  return Number.isNaN(n) ? null : n;
+};
+
+const getNonNullReleaseIds = (ids: Array<number | null>): number[] =>
+  ids.filter((id): id is number => id !== null);
+
+// Helper to convert DeviceFilterState to react-admin filter object
+export const convertToListFilters = (filters: DeviceFilterState): Record<string, unknown> => {
+  const listFilters: Record<string, unknown> = {};
+
+  if (filters.onlineStatus !== 'all') {
+    listFilters['api heartbeat state@eq'] = filters.onlineStatus;
+  }
+
+  if (filters.deviceTypeId !== null) {
+    listFilters['is of-device type@eq'] = filters.deviceTypeId;
+  }
+
+  if (filters.fleetId !== null) {
+    listFilters['belongs to-application@eq'] = filters.fleetId;
+  }
+
+  const releaseIds = getNonNullReleaseIds(filters.releaseIds);
+  if (releaseIds.length > 0) {
+    listFilters['is running-release@in'] = `(${releaseIds.join(',')})`;
+  }
+
+  if (filters.osVersion !== '') {
+    listFilters['os version@ilike'] = filters.osVersion;
+  }
+
+  return listFilters;
+};
+
+// Check if there are any active structured filters
+export const hasActiveStructuredFilters = (filters: DeviceFilterState): boolean => {
+  const releaseIds = getNonNullReleaseIds(filters.releaseIds);
+  return (
+    filters.onlineStatus !== 'all' ||
+    filters.deviceTypeId !== null ||
+    filters.fleetId !== null ||
+    releaseIds.length > 0 ||
+    filters.osVersion !== ''
+  );
+};
+
+// Helper to derive structured filters from react-admin's filterValues
+export const deriveStructuredFilters = (filterValues: Record<string, unknown>): DeviceFilterState => {
+  const onlineStatus = (filterValues['api heartbeat state@eq'] as string) || 'all';
+  const deviceTypeId = toOptionalNumber(filterValues['is of-device type@eq']);
+  const fleetId = toOptionalNumber(filterValues['belongs to-application@eq']);
+
+  // Parse release IDs from the "(1,2,3)" format, a simple comma-separated string,
+  // or an array of values. This keeps us resilient to backend/react-admin changes.
+  let releaseIds: Array<number | null> = [];
+  const releaseFilter = filterValues['is running-release@in'];
+
+  if (typeof releaseFilter === 'string') {
+    const trimmed = releaseFilter.trim();
+    const inner =
+      trimmed.startsWith('(') && trimmed.endsWith(')')
+        ? trimmed.slice(1, -1)
+        : trimmed;
+
+    releaseIds = inner
+      .split(',')
+      .map((id) => Number(id.trim()))
+      .filter((id) => !Number.isNaN(id));
+  } else if (Array.isArray(releaseFilter)) {
+    releaseIds = releaseFilter
+      .map((id) => Number(id))
+      .filter((id) => !Number.isNaN(id));
+  }
+
+  const osVersion = (filterValues['os version@ilike'] as string) || '';
+
+  return {
+    onlineStatus: onlineStatus as DeviceFilterState['onlineStatus'],
+    deviceTypeId,
+    fleetId,
+    releaseIds,
+    osVersion,
+  };
+};
+
+// Custom filter component for structured filtering (like ActorFilter pattern)
+interface DeviceStructuredFilterProps {
+  alwaysOn?: boolean;
+}
+
+const STRUCTURED_FILTER_KEYS = [
+  'api heartbeat state@eq',
+  'is of-device type@eq',
+  'belongs to-application@eq',
+  'is running-release@in',
+  'os version@ilike',
+] as const;
+
+const DeviceStructuredFilter: React.FC<DeviceStructuredFilterProps> = ({
+  // alwaysOn is used by react-admin's List component to determine filter visibility
+  alwaysOn: _alwaysOn,
+}) => {
+  const { filterValues, setFilters } = useListContext();
+  const [isFilterModalOpen, setIsFilterModalOpen] = React.useState(false);
+
+  // Derive structured filters directly from react-admin's filterValues (single source of truth)
+  const structuredFilters = React.useMemo(() => deriveStructuredFilters(filterValues), [filterValues]);
+
+  const handleApplyFilters = React.useCallback(
+    (newFilters: DeviceFilterState) => {
+      const convertedFilters = convertToListFilters(newFilters);
+
+      // Start from current filters, remove any existing structured keys,
+      // then overlay the new structured filters. This preserves any
+      // non-structured filters (e.g. text search, quick filters).
+      const nextFilters: Record<string, unknown> = { ...filterValues };
+      for (const key of STRUCTURED_FILTER_KEYS) {
+        delete nextFilters[key];
+      }
+
+      Object.assign(nextFilters, convertedFilters);
+
+      setFilters(nextFilters, undefined, false);
+    },
+    [filterValues, setFilters]
+  );
+
+  const handleRemoveFilter = React.useCallback(
+    (filterKey: keyof DeviceFilterState) => {
+      // Create updated filters based on current derived state
+      const updatedFilters: DeviceFilterState = { ...structuredFilters };
+
+      switch (filterKey) {
+        case 'onlineStatus':
+          updatedFilters.onlineStatus = 'all';
+          break;
+        case 'deviceTypeId':
+          updatedFilters.deviceTypeId = null;
+          break;
+        case 'fleetId':
+          updatedFilters.fleetId = null;
+          break;
+        case 'releaseIds':
+          updatedFilters.releaseIds = [];
+          break;
+        case 'osVersion':
+          updatedFilters.osVersion = '';
+          break;
+      }
+
+      handleApplyFilters(updatedFilters);
+    },
+    [structuredFilters, handleApplyFilters]
+  );
+
+  const hasActiveFilters = hasActiveStructuredFilters(structuredFilters);
+
+  return (
+    <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+      <DeviceFilterButton onClick={() => setIsFilterModalOpen(true)} hasActiveFilters={hasActiveFilters} />
+      {hasActiveFilters && <ActiveFilterChips filters={structuredFilters} onRemoveFilter={handleRemoveFilter} />}
+      <DeviceFilterModal
+        open={isFilterModalOpen}
+        onClose={() => setIsFilterModalOpen(false)}
+        onApply={handleApplyFilters}
+        currentFilters={structuredFilters}
+      />
+    </Box>
+  );
+};
+
+export default DeviceStructuredFilter;
+


### PR DESCRIPTION
This PR adds a structured filtering UI for devices, including a modal for selecting filters and active filter chips for quick visibility and removal. The device list toolbar has been updated to integrate the new filter controls alongside the existing search.

This improves device discovery and makes it easier to filter by multiple attributes at once.

- Added `DeviceFilterModal` for advanced filtering options including online status, device type, fleet, and OS version.
- Introduced `ActiveFilterChips` component to display currently active filters and allow removal.
- Enhanced `DeviceStructuredFilter` to integrate new filtering capabilities into the device list view.
- Updated device list actions to include new filter buttons and improved UI for filter management.