### PR TITLE
Supervisor version update from the webui (catalog, seeding, registry mirroring, device targets)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,6 @@ jobs:
         run: npm run lint
 
       - name: Testing
-        if: false # Jest (or similar) needs added to dev-dependencies and configured properly...
         run: npm run test
 
       - name: Build

--- a/README.md
+++ b/README.md
@@ -34,6 +34,41 @@ These variables can be supplied through the standard Vite `.env` files (for exam
 `.env.<mode>` when invoking `vite --mode <mode>`). The active mode is already set for the provided `npm run dev` and
 `npm run dev:local` scripts.
 
+### Supervisor updates
+
+Two additional server-side variables configure the supervisor version management feature:
+
+- `BALENACLOUD_TOKEN` A balenaCloud JWT (any account, e.g. a free one) used to pull supervisor images from
+  `registry2.balena-cloud.com` when mirroring them into your instance registry. **Optional**: without it, version
+  listing still works, but seeding/updating to a version that is not yet mirrored fails with a clear notice in the ui.
+- `OPEN_BALENA_REGISTRY_URL` The base URL of your instance registry, e.g. `https://registry2.openbalena.local`.
+  **Optional**: defaults to deriving the registry host from `REACT_APP_OPEN_BALENA_API_URL` by replacing the leftmost
+  host label with `registry2` (`api.openbalena.local` → `registry2.openbalena.local`).
+- `BALENACLOUD_API_URL` Base URL of the balenaCloud API used for the public supervisor catalog. **Optional**, defaults
+  to `https://api.balena-cloud.com`.
+
+## Supervisor Version Management
+
+openBalena ships without any supervisor releases, so devices keep the supervisor that was baked into the flashed OS
+image. This ui adds a one-click supervisor update:
+
+- The **device dashboard** shows the current and any pending target supervisor version and offers an "Update Supervisor"
+  dialog listing the available versions for the device's CPU architecture (sourced from balenaCloud's public supervisor
+  catalog, deduplicated and ordered newest-first). Versions older than the device's current one are listed but disabled
+  — open-balena-api rejects supervisor downgrades.
+- The **device list** offers a bulk action for the selected devices (they must share one device type), and the **fleet
+  edit page** can update every device of a fleet (grouped by device type).
+
+On first use of a version, the ui server seeds it into your instance: it creates the public
+`balena_os/<arch>-supervisor` application, services and image metadata with your own user credentials, copies the image
+bytes byte-identically (by manifest digest, config and layers included) from balenaCloud's registry into your instance
+registry, and only then creates the `success` release. Afterwards it sets each device's target supervisor release
+(`should be managed by-release`) with your credentials; the instance API enforces the no-downgrade rule per device and
+the ui reports per-device results.
+
+All `/supervisor-releases/*` endpoints of the ui server require a valid ui JWT; instance writes always run with the
+calling user's token. Validate on a real device before rolling a whole fleet.
+
 ## Exposing Device Connection Endpoints
 
 Each device has a "Connect" button which uses balena image labels to discover available services on that device. To make

--- a/openspec/changes/add-supervisor-version-management/design.md
+++ b/openspec/changes/add-supervisor-version-management/design.md
@@ -1,0 +1,66 @@
+# Design: Supervisor version management
+
+## Context
+
+- openBalena instances ship **no supervisor releases**: there are no `balena_os/<arch>-supervisor` applications, no releases, no images (verified on the production instance: `application?$filter=startswith(slug,'balena_os/')` returns `[]`). Upstream forums confirm supervisor updates were never wired up in openBalena.
+- The delivery machinery **does** exist in open-balena-api:
+  - Device field `should be managed by-release` (FK to `release`); `PATCH device` with this field is validated by supervisor-app hooks (upgrade-only, semver check, release must be `status=success` with semver > 0, belong to a public non-host app whose device type's CPU arch matches).
+  - State v3 (`/device/v3/<uuid>/state`) includes `should_be_managed_by__release` as a target release — modern supervisors (the instance runs 19.0.8) consume this.
+- balenaCloud exposes the supervisor catalog publicly (verified anonymously):
+  - App: `GET {BC}/v6/application?$filter=slug eq 'balena_os/<arch>-supervisor'` → id, `is_for__device_type`, uuid; `is_public: true`, `is_host: false`, `is_of__class: 'app'`.
+  - Releases: `GET {BC}/v6/release?$filter=belongs_to__application eq <id> and status eq 'success'&$orderby=id desc` → `semver`, `raw_version`, `composition`, `variant`.
+  - `release_image` and `image` (with `is_stored_at__image_location` = `registry2.balena-cloud.com/v2/<32-hex-repo>` and `content_hash` = `sha256:…`, plus `is_a_build_of__service` → `service_name`) are publicly readable.
+- **Image bytes are the hard part**: balenaCloud's registry rejects anonymous pulls (verified: anonymous `/auth/v1/token` token → manifest HEAD `401`). Pulling requires a balenaCloud JWT (any account, e.g. free) via `Authorization: Bearer` on the token endpoint. Pushing to the instance registry uses the instance's own `/auth/v1/token` with the admin user's JWT — the same flow `balena push` uses.
+
+## Goals
+
+- One click from a device (or fleet) page to a newer supervisor version.
+- Supervisor images become available through the instance's own registry (mirrored once per (arch, version)).
+- No new authority: all instance writes happen with the logged-in UI user's JWT (admin in openBalena), all balenaCloud reads are anonymous, pulls use the server-level `BALENACLOUD_TOKEN`.
+
+## Decisions
+
+### D1: Server-mediated seed + mirror + patch
+
+The browser cannot talk to balenaCloud's registry, and instance writes must be auditable. The UI server (Express, already JWT-guarded) mediates:
+1. **List** — anonymous balenaCloud reads, merged with instance state.
+2. **Seed** — idempotently create app/services/images metadata in the instance using the caller's forwarded JWT, then mirror image bytes, then create the release + `release_image` links last (never a release referencing un-mirrored images).
+3. **Update** — PATCH device(s) `should be managed by-release` with the caller's JWT (the API enforces no-downgrade).
+
+### D2: Byte-identical manifest mirroring
+
+Copy manifests as-is (byte-identical, by digest) plus every referenced blob (config + layers, recursively for manifest lists/indices). Because digests are preserved, the seeded `image.content_hash` from balenaCloud stays valid, and `location@digest` emitted by state v3 resolves in the instance registry.
+
+- Source auth: `{BC}/auth/v1/token?service=registry2.balena-cloud.com&scope=repository:<repo>:pull` with `Authorization: Bearer $BALENACLOUD_TOKEN`.
+- Target auth: `{API}/auth/v1/token?service=<registryHost>&scope=repository:<repo>:pull,push` with the caller's JWT.
+- Target host: `OPEN_BALENA_REGISTRY_URL`, default derived from the API URL host by replacing the leftmost label with `registry2` (e.g. `api.balena.example.com` → `registry2.balena.example.com`).
+- Idempotent: HEAD manifest by digest in the target; skip blobs that already exist.
+- Per (arch, version) in-process lock; concurrent seeds await the first.
+
+### D3: Instance data shape mirrors balenaCloud exactly
+
+Seeded rows replicate the balenaCloud shape the device-side supervisor expects from state v3: app `<arch>-supervisor` (slug `balena_os/<arch>-supervisor`, public, non-host), services with the same `service_name`s, images with instance-registry locations, release with `raw_version` = semver, semver fields, `status: 'success'`, `is_final: true`, and the balenaCloud `composition` copied verbatim.
+
+### D4: Version listing semantics
+
+`GET /supervisor-releases/versions?deviceType=<slug>` resolves the device type → CPU arch → balenaCloud `<arch>-supervisor` app, dedupes releases by `semver` (newest raw per semver), orders semver-desc, and annotates each entry with `seeded` (instance release id present). Versions older than the device's (or a provided) current supervisor are still listed — the UI disables them ("downgrade not allowed"); the API would reject them anyway.
+
+### D5: Update actions — device and fleet bulk
+
+- `POST /supervisor-releases/update` `{ version, deviceType, deviceIds: number[] }` — ensures seeded (seeds if missing), then PATCHes each device with the caller's JWT. Per-device results (`updated` / `rejected: <api message>`); bulk tolerates partial failure. Frontend offers this from the device page (single device, preselected) and as a bulk action on the device list / fleet page (devices grouped by device type client-side, one call per type).
+
+## Risks / Trade-offs
+
+- **Device-side self-update semantics**: state v3 includes the supervisor release; the device supervisor's own update trigger follows balenaCloud semantics because the shape is replicated faithfully. Real-device acceptance testing is required (documented; user validates on a live device before rolling out fleet-wide).
+- **Mirror size**: ~100–250 MB per (arch, version); registry storage grows per seeded version. Acceptable: seeding is explicit and per-version.
+- **`BALENACLOUD_TOKEN` required for seeding**: without it, listing works, seeding/mirroring returns a clear error, and the UI shows an explanatory notice.
+- **balenaCloud dependency**: catalog and bytes come from balenaCloud; an outage only blocks new seeds, not updates to already-seeded versions.
+- **In-process locks**: single-instance UI server assumption (consistent with the OS image cache design).
+
+## Migration Plan
+
+Purely additive: new routes/controller, new deps (`balena-semver` for ordering — pure JS), new env vars (`BALENACLOUD_TOKEN`, `OPEN_BALENA_REGISTRY_URL`; `BALENACLOUD_API_URL` shared). No changes to existing resources.
+
+## Open Questions
+
+- None blocking.

--- a/openspec/changes/add-supervisor-version-management/design.md
+++ b/openspec/changes/add-supervisor-version-management/design.md
@@ -2,64 +2,99 @@
 
 ## Context
 
-- openBalena instances ship **no supervisor releases**: there are no `balena_os/<arch>-supervisor` applications, no releases, no images (verified on the production instance: `application?$filter=startswith(slug,'balena_os/')` returns `[]`). Upstream forums confirm supervisor updates were never wired up in openBalena.
+- openBalena instances ship **no supervisor releases**: there are no `balena_os/<arch>-supervisor` applications, no
+  releases, no images (verified on the production instance: `application?$filter=startswith(slug,'balena_os/')` returns
+  `[]`). Upstream forums confirm supervisor updates were never wired up in openBalena.
 - The delivery machinery **does** exist in open-balena-api:
-  - Device field `should be managed by-release` (FK to `release`); `PATCH device` with this field is validated by supervisor-app hooks (upgrade-only, semver check, release must be `status=success` with semver > 0, belong to a public non-host app whose device type's CPU arch matches).
-  - State v3 (`/device/v3/<uuid>/state`) includes `should_be_managed_by__release` as a target release — modern supervisors (the instance runs 19.0.8) consume this.
+  - Device field `should be managed by-release` (FK to `release`); `PATCH device` with this field is validated by
+    supervisor-app hooks (upgrade-only, semver check, release must be `status=success` with semver > 0, belong to a
+    public non-host app whose device type's CPU arch matches).
+  - State v3 (`/device/v3/<uuid>/state`) includes `should_be_managed_by__release` as a target release — modern
+    supervisors (the instance runs 19.0.8) consume this.
 - balenaCloud exposes the supervisor catalog publicly (verified anonymously):
-  - App: `GET {BC}/v6/application?$filter=slug eq 'balena_os/<arch>-supervisor'` → id, `is_for__device_type`, uuid; `is_public: true`, `is_host: false`, `is_of__class: 'app'`.
-  - Releases: `GET {BC}/v6/release?$filter=belongs_to__application eq <id> and status eq 'success'&$orderby=id desc` → `semver`, `raw_version`, `composition`, `variant`.
-  - `release_image` and `image` (with `is_stored_at__image_location` = `registry2.balena-cloud.com/v2/<32-hex-repo>` and `content_hash` = `sha256:…`, plus `is_a_build_of__service` → `service_name`) are publicly readable.
-- **Image bytes are the hard part**: balenaCloud's registry rejects anonymous pulls (verified: anonymous `/auth/v1/token` token → manifest HEAD `401`). Pulling requires a balenaCloud JWT (any account, e.g. free) via `Authorization: Bearer` on the token endpoint. Pushing to the instance registry uses the instance's own `/auth/v1/token` with the admin user's JWT — the same flow `balena push` uses.
+  - App: `GET {BC}/v6/application?$filter=slug eq 'balena_os/<arch>-supervisor'` → id, `is_for__device_type`, uuid;
+    `is_public: true`, `is_host: false`, `is_of__class: 'app'`.
+  - Releases: `GET {BC}/v6/release?$filter=belongs_to__application eq <id> and status eq 'success'&$orderby=id desc` →
+    `semver`, `raw_version`, `composition`, `variant`.
+  - `release_image` and `image` (with `is_stored_at__image_location` = `registry2.balena-cloud.com/v2/<32-hex-repo>` and
+    `content_hash` = `sha256:…`, plus `is_a_build_of__service` → `service_name`) are publicly readable.
+- **Image bytes are the hard part**: balenaCloud's registry rejects anonymous pulls (verified: anonymous
+  `/auth/v1/token` token → manifest HEAD `401`). Pulling requires a balenaCloud JWT (any account, e.g. free) via
+  `Authorization: Bearer` on the token endpoint. Pushing to the instance registry uses the instance's own
+  `/auth/v1/token` with the admin user's JWT — the same flow `balena push` uses.
 
 ## Goals
 
 - One click from a device (or fleet) page to a newer supervisor version.
 - Supervisor images become available through the instance's own registry (mirrored once per (arch, version)).
-- No new authority: all instance writes happen with the logged-in UI user's JWT (admin in openBalena), all balenaCloud reads are anonymous, pulls use the server-level `BALENACLOUD_TOKEN`.
+- No new authority: all instance writes happen with the logged-in UI user's JWT (admin in openBalena), all balenaCloud
+  reads are anonymous, pulls use the server-level `BALENACLOUD_TOKEN`.
 
 ## Decisions
 
 ### D1: Server-mediated seed + mirror + patch
 
-The browser cannot talk to balenaCloud's registry, and instance writes must be auditable. The UI server (Express, already JWT-guarded) mediates:
+The browser cannot talk to balenaCloud's registry, and instance writes must be auditable. The UI server (Express,
+already JWT-guarded) mediates:
+
 1. **List** — anonymous balenaCloud reads, merged with instance state.
-2. **Seed** — idempotently create app/services/images metadata in the instance using the caller's forwarded JWT, then mirror image bytes, then create the release + `release_image` links last (never a release referencing un-mirrored images).
+2. **Seed** — idempotently create app/services/images metadata in the instance using the caller's forwarded JWT, then
+   mirror image bytes, then create the release + `release_image` links last (never a release referencing un-mirrored
+   images).
 3. **Update** — PATCH device(s) `should be managed by-release` with the caller's JWT (the API enforces no-downgrade).
 
 ### D2: Byte-identical manifest mirroring
 
-Copy manifests as-is (byte-identical, by digest) plus every referenced blob (config + layers, recursively for manifest lists/indices). Because digests are preserved, the seeded `image.content_hash` from balenaCloud stays valid, and `location@digest` emitted by state v3 resolves in the instance registry.
+Copy manifests as-is (byte-identical, by digest) plus every referenced blob (config + layers, recursively for manifest
+lists/indices). Because digests are preserved, the seeded `image.content_hash` from balenaCloud stays valid, and
+`location@digest` emitted by state v3 resolves in the instance registry.
 
-- Source auth: `{BC}/auth/v1/token?service=registry2.balena-cloud.com&scope=repository:<repo>:pull` with `Authorization: Bearer $BALENACLOUD_TOKEN`.
+- Source auth: `{BC}/auth/v1/token?service=registry2.balena-cloud.com&scope=repository:<repo>:pull` with
+  `Authorization: Bearer $BALENACLOUD_TOKEN`.
 - Target auth: `{API}/auth/v1/token?service=<registryHost>&scope=repository:<repo>:pull,push` with the caller's JWT.
-- Target host: `OPEN_BALENA_REGISTRY_URL`, default derived from the API URL host by replacing the leftmost label with `registry2` (e.g. `api.balena.example.com` → `registry2.balena.example.com`).
+- Target host: `OPEN_BALENA_REGISTRY_URL`, default derived from the API URL host by replacing the leftmost label with
+  `registry2` (e.g. `api.balena.example.com` → `registry2.balena.example.com`).
 - Idempotent: HEAD manifest by digest in the target; skip blobs that already exist.
 - Per (arch, version) in-process lock; concurrent seeds await the first.
 
 ### D3: Instance data shape mirrors balenaCloud exactly
 
-Seeded rows replicate the balenaCloud shape the device-side supervisor expects from state v3: app `<arch>-supervisor` (slug `balena_os/<arch>-supervisor`, public, non-host), services with the same `service_name`s, images with instance-registry locations, release with `raw_version` = semver, semver fields, `status: 'success'`, `is_final: true`, and the balenaCloud `composition` copied verbatim.
+Seeded rows replicate the balenaCloud shape the device-side supervisor expects from state v3: app `<arch>-supervisor`
+(slug `balena_os/<arch>-supervisor`, public, non-host), services with the same `service_name`s, images with
+instance-registry locations, release with `raw_version` = semver, semver fields, `status: 'success'`, `is_final: true`,
+and the balenaCloud `composition` copied verbatim.
 
 ### D4: Version listing semantics
 
-`GET /supervisor-releases/versions?deviceType=<slug>` resolves the device type → CPU arch → balenaCloud `<arch>-supervisor` app, dedupes releases by `semver` (newest raw per semver), orders semver-desc, and annotates each entry with `seeded` (instance release id present). Versions older than the device's (or a provided) current supervisor are still listed — the UI disables them ("downgrade not allowed"); the API would reject them anyway.
+`GET /supervisor-releases/versions?deviceType=<slug>` resolves the device type → CPU arch → balenaCloud
+`<arch>-supervisor` app, dedupes releases by `semver` (newest raw per semver), orders semver-desc, and annotates each
+entry with `seeded` (instance release id present). Versions older than the device's (or a provided) current supervisor
+are still listed — the UI disables them ("downgrade not allowed"); the API would reject them anyway.
 
 ### D5: Update actions — device and fleet bulk
 
-- `POST /supervisor-releases/update` `{ version, deviceType, deviceIds: number[] }` — ensures seeded (seeds if missing), then PATCHes each device with the caller's JWT. Per-device results (`updated` / `rejected: <api message>`); bulk tolerates partial failure. Frontend offers this from the device page (single device, preselected) and as a bulk action on the device list / fleet page (devices grouped by device type client-side, one call per type).
+- `POST /supervisor-releases/update` `{ version, deviceType, deviceIds: number[] }` — ensures seeded (seeds if missing),
+  then PATCHes each device with the caller's JWT. Per-device results (`updated` / `rejected: <api message>`); bulk
+  tolerates partial failure. Frontend offers this from the device page (single device, preselected) and as a bulk action
+  on the device list / fleet page (devices grouped by device type client-side, one call per type).
 
 ## Risks / Trade-offs
 
-- **Device-side self-update semantics**: state v3 includes the supervisor release; the device supervisor's own update trigger follows balenaCloud semantics because the shape is replicated faithfully. Real-device acceptance testing is required (documented; user validates on a live device before rolling out fleet-wide).
-- **Mirror size**: ~100–250 MB per (arch, version); registry storage grows per seeded version. Acceptable: seeding is explicit and per-version.
-- **`BALENACLOUD_TOKEN` required for seeding**: without it, listing works, seeding/mirroring returns a clear error, and the UI shows an explanatory notice.
-- **balenaCloud dependency**: catalog and bytes come from balenaCloud; an outage only blocks new seeds, not updates to already-seeded versions.
+- **Device-side self-update semantics**: state v3 includes the supervisor release; the device supervisor's own update
+  trigger follows balenaCloud semantics because the shape is replicated faithfully. Real-device acceptance testing is
+  required (documented; user validates on a live device before rolling out fleet-wide).
+- **Mirror size**: ~100–250 MB per (arch, version); registry storage grows per seeded version. Acceptable: seeding is
+  explicit and per-version.
+- **`BALENACLOUD_TOKEN` required for seeding**: without it, listing works, seeding/mirroring returns a clear error, and
+  the UI shows an explanatory notice.
+- **balenaCloud dependency**: catalog and bytes come from balenaCloud; an outage only blocks new seeds, not updates to
+  already-seeded versions.
 - **In-process locks**: single-instance UI server assumption (consistent with the OS image cache design).
 
 ## Migration Plan
 
-Purely additive: new routes/controller, new deps (`balena-semver` for ordering — pure JS), new env vars (`BALENACLOUD_TOKEN`, `OPEN_BALENA_REGISTRY_URL`; `BALENACLOUD_API_URL` shared). No changes to existing resources.
+Purely additive: new routes/controller, new deps (`balena-semver` for ordering — pure JS), new env vars
+(`BALENACLOUD_TOKEN`, `OPEN_BALENA_REGISTRY_URL`; `BALENACLOUD_API_URL` shared). No changes to existing resources.
 
 ## Open Questions
 

--- a/openspec/changes/add-supervisor-version-management/proposal.md
+++ b/openspec/changes/add-supervisor-version-management/proposal.md
@@ -1,0 +1,17 @@
+## Why
+
+openBalena has no supervisor-update capability at all: instances ship zero supervisor releases (no `balena_os/<arch>-supervisor` apps), so supervisors stay frozen at the version baked into the flashed OS image. Updating a device's supervisor today is impossible from the webui — the API machinery (`should be managed by-release` + no-downgrade hooks + state v3 delivery) exists but there is nothing to point it at. We want a one-click "update supervisor to version X" from the device (or fleet) page, including making the selected supervisor version actually available to devices. Tracked in volkermauel/open-balena-ui#2.
+
+## What Changes
+
+- New capability `supervisor-version-management`:
+  - New authenticated UI-server routes that list supervisor versions for a device type (balenaCloud public catalog, merged with instance state), seed a version into the instance (metadata via the caller's JWT + byte-identical image mirroring from balenaCloud's registry into the instance registry using `BALENACLOUD_TOKEN`), and set device targets (`PATCH device "should be managed by-release"`, single or bulk).
+  - Device page: Supervisor card gains current/target version display and an "Update Supervisor" dialog (version list, seed progress, downgrade prevention, mirroring-not-configured notice).
+  - Bulk "Update Supervisor" action for selected devices and fleet-wide.
+- New npm dependency: `balena-semver` (pure JS, supervisor semver ordering).
+- New environment variables: `BALENACLOUD_TOKEN`, `OPEN_BALENA_REGISTRY_URL` (default derived from the API URL host).
+- New `npm test` script running `node:test` unit tests via `tsx` (mirrors the OS-image change if not already present).
+
+## Capability
+
+- New capability: `supervisor-version-management` (spec delta in `specs/supervisor-version-management/spec.md`)

--- a/openspec/changes/add-supervisor-version-management/proposal.md
+++ b/openspec/changes/add-supervisor-version-management/proposal.md
@@ -1,12 +1,21 @@
 ## Why
 
-openBalena has no supervisor-update capability at all: instances ship zero supervisor releases (no `balena_os/<arch>-supervisor` apps), so supervisors stay frozen at the version baked into the flashed OS image. Updating a device's supervisor today is impossible from the webui — the API machinery (`should be managed by-release` + no-downgrade hooks + state v3 delivery) exists but there is nothing to point it at. We want a one-click "update supervisor to version X" from the device (or fleet) page, including making the selected supervisor version actually available to devices. Tracked in volkermauel/open-balena-ui#2.
+openBalena has no supervisor-update capability at all: instances ship zero supervisor releases (no
+`balena_os/<arch>-supervisor` apps), so supervisors stay frozen at the version baked into the flashed OS image. Updating
+a device's supervisor today is impossible from the webui — the API machinery (`should be managed by-release` +
+no-downgrade hooks + state v3 delivery) exists but there is nothing to point it at. We want a one-click "update
+supervisor to version X" from the device (or fleet) page, including making the selected supervisor version actually
+available to devices. Tracked in volkermauel/open-balena-ui#2.
 
 ## What Changes
 
 - New capability `supervisor-version-management`:
-  - New authenticated UI-server routes that list supervisor versions for a device type (balenaCloud public catalog, merged with instance state), seed a version into the instance (metadata via the caller's JWT + byte-identical image mirroring from balenaCloud's registry into the instance registry using `BALENACLOUD_TOKEN`), and set device targets (`PATCH device "should be managed by-release"`, single or bulk).
-  - Device page: Supervisor card gains current/target version display and an "Update Supervisor" dialog (version list, seed progress, downgrade prevention, mirroring-not-configured notice).
+  - New authenticated UI-server routes that list supervisor versions for a device type (balenaCloud public catalog,
+    merged with instance state), seed a version into the instance (metadata via the caller's JWT + byte-identical image
+    mirroring from balenaCloud's registry into the instance registry using `BALENACLOUD_TOKEN`), and set device targets
+    (`PATCH device "should be managed by-release"`, single or bulk).
+  - Device page: Supervisor card gains current/target version display and an "Update Supervisor" dialog (version list,
+    seed progress, downgrade prevention, mirroring-not-configured notice).
   - Bulk "Update Supervisor" action for selected devices and fleet-wide.
 - New npm dependency: `balena-semver` (pure JS, supervisor semver ordering).
 - New environment variables: `BALENACLOUD_TOKEN`, `OPEN_BALENA_REGISTRY_URL` (default derived from the API URL host).

--- a/openspec/changes/add-supervisor-version-management/specs/supervisor-version-management/spec.md
+++ b/openspec/changes/add-supervisor-version-management/specs/supervisor-version-management/spec.md
@@ -4,12 +4,15 @@
 
 ### Requirement: Supervisor version listing
 
-The system SHALL list available supervisor versions for a device type, sourced from balenaCloud's public supervisor catalog for the device type's CPU architecture, deduplicated and ordered newest-first, annotated with whether each version is already seeded into the instance.
+The system SHALL list available supervisor versions for a device type, sourced from balenaCloud's public supervisor
+catalog for the device type's CPU architecture, deduplicated and ordered newest-first, annotated with whether each
+version is already seeded into the instance.
 
 #### Scenario: List versions for a device type
 
 - **WHEN** an authenticated client requests `GET /supervisor-releases/versions?deviceType=<slug>`
-- **THEN** the response contains unique supervisor versions for that device type's architecture, ordered semver-descending, each marked `seeded` or not
+- **THEN** the response contains unique supervisor versions for that device type's architecture, ordered
+  semver-descending, each marked `seeded` or not
 
 #### Scenario: Upstream unavailable
 
@@ -18,12 +21,15 @@ The system SHALL list available supervisor versions for a device type, sourced f
 
 ### Requirement: Supervisor release seeding
 
-The system SHALL idempotently seed a supervisor version into the openBalena instance on request: public supervisor application, services, images (instance-registry locations), mirrored image bytes, and the release with `release_image` links — created in an order that never exposes a release referencing un-mirrored images.
+The system SHALL idempotently seed a supervisor version into the openBalena instance on request: public supervisor
+application, services, images (instance-registry locations), mirrored image bytes, and the release with `release_image`
+links — created in an order that never exposes a release referencing un-mirrored images.
 
 #### Scenario: Seed a version
 
 - **WHEN** an authenticated client requests `POST /supervisor-releases/seed {deviceType, version}`
-- **THEN** the supervisor app, services, images, mirrored bytes, and release exist in the instance, and the response reports the instance release id
+- **THEN** the supervisor app, services, images, mirrored bytes, and release exist in the instance, and the response
+  reports the instance release id
 
 #### Scenario: Re-seed is a no-op
 
@@ -37,12 +43,15 @@ The system SHALL idempotently seed a supervisor version into the openBalena inst
 
 ### Requirement: Image mirroring
 
-The system SHALL copy supervisor image manifests byte-identically (by digest) with all referenced blobs from balenaCloud's registry into the instance registry, skipping blobs that already exist, using the balenaCloud token for pulls and the caller's instance JWT for pushes.
+The system SHALL copy supervisor image manifests byte-identically (by digest) with all referenced blobs from
+balenaCloud's registry into the instance registry, skipping blobs that already exist, using the balenaCloud token for
+pulls and the caller's instance JWT for pushes.
 
 #### Scenario: Digest preservation
 
 - **WHEN** an image is mirrored
-- **THEN** pulling the manifest by its balenaCloud digest from the instance registry yields the byte-identical manifest, so seeded `content_hash` values remain valid
+- **THEN** pulling the manifest by its balenaCloud digest from the instance registry yields the byte-identical manifest,
+  so seeded `content_hash` values remain valid
 
 #### Scenario: Existing blobs are not re-copied
 
@@ -51,7 +60,8 @@ The system SHALL copy supervisor image manifests byte-identically (by digest) wi
 
 ### Requirement: Device supervisor target update
 
-The system SHALL set a device's target supervisor release via `PATCH device "should be managed by-release"` using the requesting user's JWT, for one or many devices, and SHALL report per-device results.
+The system SHALL set a device's target supervisor release via `PATCH device "should be managed by-release"` using the
+requesting user's JWT, for one or many devices, and SHALL report per-device results.
 
 #### Scenario: Update one device
 
@@ -61,7 +71,8 @@ The system SHALL set a device's target supervisor release via `PATCH device "sho
 #### Scenario: Downgrade rejected by the API is surfaced
 
 - **WHEN** the target version is older than a device's current supervisor
-- **THEN** that device's result is `rejected` with the API's error message, and other devices in the same request are unaffected
+- **THEN** that device's result is `rejected` with the API's error message, and other devices in the same request are
+  unaffected
 
 #### Scenario: Fleet bulk update
 
@@ -79,7 +90,8 @@ The system SHALL report a device's current supervisor version and target (pendin
 
 ### Requirement: Authentication
 
-All supervisor-release endpoints SHALL require a valid UI JWT and be dos-protected, consistent with existing server routes; instance writes SHALL be performed with the caller's own JWT.
+All supervisor-release endpoints SHALL require a valid UI JWT and be dos-protected, consistent with existing server
+routes; instance writes SHALL be performed with the caller's own JWT.
 
 #### Scenario: Missing token
 
@@ -88,12 +100,14 @@ All supervisor-release endpoints SHALL require a valid UI JWT and be dos-protect
 
 ### Requirement: UI entry points
 
-The UI SHALL offer supervisor updates from the device page (single device, preselected version list) and as bulk actions for selected devices and for a whole fleet.
+The UI SHALL offer supervisor updates from the device page (single device, preselected version list) and as bulk actions
+for selected devices and for a whole fleet.
 
 #### Scenario: Device page update
 
 - **WHEN** the user opens "Update Supervisor" on a device
-- **THEN** a dialog lists available versions, marks the current one, disables downgrades, and applies the update on confirmation with progress feedback
+- **THEN** a dialog lists available versions, marks the current one, disables downgrades, and applies the update on
+  confirmation with progress feedback
 
 #### Scenario: Downgrades disabled in the dialog
 

--- a/openspec/changes/add-supervisor-version-management/specs/supervisor-version-management/spec.md
+++ b/openspec/changes/add-supervisor-version-management/specs/supervisor-version-management/spec.md
@@ -1,0 +1,101 @@
+# Supervisor Version Management — spec delta
+
+## ADDED Requirements
+
+### Requirement: Supervisor version listing
+
+The system SHALL list available supervisor versions for a device type, sourced from balenaCloud's public supervisor catalog for the device type's CPU architecture, deduplicated and ordered newest-first, annotated with whether each version is already seeded into the instance.
+
+#### Scenario: List versions for a device type
+
+- **WHEN** an authenticated client requests `GET /supervisor-releases/versions?deviceType=<slug>`
+- **THEN** the response contains unique supervisor versions for that device type's architecture, ordered semver-descending, each marked `seeded` or not
+
+#### Scenario: Upstream unavailable
+
+- **WHEN** balenaCloud cannot be reached
+- **THEN** the endpoint responds with a non-success status identifying the upstream failure
+
+### Requirement: Supervisor release seeding
+
+The system SHALL idempotently seed a supervisor version into the openBalena instance on request: public supervisor application, services, images (instance-registry locations), mirrored image bytes, and the release with `release_image` links — created in an order that never exposes a release referencing un-mirrored images.
+
+#### Scenario: Seed a version
+
+- **WHEN** an authenticated client requests `POST /supervisor-releases/seed {deviceType, version}`
+- **THEN** the supervisor app, services, images, mirrored bytes, and release exist in the instance, and the response reports the instance release id
+
+#### Scenario: Re-seed is a no-op
+
+- **WHEN** the same version is seeded again
+- **THEN** existing rows are reused, no duplicate rows or image copies are created
+
+#### Scenario: Mirroring not configured
+
+- **WHEN** `BALENACLOUD_TOKEN` is not set on the server
+- **THEN** seeding fails with a clear "mirroring not configured" error while version listing continues to work
+
+### Requirement: Image mirroring
+
+The system SHALL copy supervisor image manifests byte-identically (by digest) with all referenced blobs from balenaCloud's registry into the instance registry, skipping blobs that already exist, using the balenaCloud token for pulls and the caller's instance JWT for pushes.
+
+#### Scenario: Digest preservation
+
+- **WHEN** an image is mirrored
+- **THEN** pulling the manifest by its balenaCloud digest from the instance registry yields the byte-identical manifest, so seeded `content_hash` values remain valid
+
+#### Scenario: Existing blobs are not re-copied
+
+- **WHEN** a blob referenced by a manifest already exists in the target registry
+- **THEN** the mirror step skips that blob
+
+### Requirement: Device supervisor target update
+
+The system SHALL set a device's target supervisor release via `PATCH device "should be managed by-release"` using the requesting user's JWT, for one or many devices, and SHALL report per-device results.
+
+#### Scenario: Update one device
+
+- **WHEN** a client requests `POST /supervisor-releases/update` with a single device id and a seeded version
+- **THEN** the device's target supervisor release is set to that version's instance release
+
+#### Scenario: Downgrade rejected by the API is surfaced
+
+- **WHEN** the target version is older than a device's current supervisor
+- **THEN** that device's result is `rejected` with the API's error message, and other devices in the same request are unaffected
+
+#### Scenario: Fleet bulk update
+
+- **WHEN** the action is invoked for multiple devices of a fleet
+- **THEN** devices are updated per device type and a summary of updated/rejected devices is returned
+
+### Requirement: Supervisor status
+
+The system SHALL report a device's current supervisor version and target (pending) supervisor release.
+
+#### Scenario: Pending target visible
+
+- **WHEN** a device has a target supervisor release set that differs from its reported version
+- **THEN** the status endpoint and the device page show the pending target version
+
+### Requirement: Authentication
+
+All supervisor-release endpoints SHALL require a valid UI JWT and be dos-protected, consistent with existing server routes; instance writes SHALL be performed with the caller's own JWT.
+
+#### Scenario: Missing token
+
+- **WHEN** any `/supervisor-releases/*` endpoint is called without a valid `Authorization: Bearer` header
+- **THEN** the endpoint responds 401
+
+### Requirement: UI entry points
+
+The UI SHALL offer supervisor updates from the device page (single device, preselected version list) and as bulk actions for selected devices and for a whole fleet.
+
+#### Scenario: Device page update
+
+- **WHEN** the user opens "Update Supervisor" on a device
+- **THEN** a dialog lists available versions, marks the current one, disables downgrades, and applies the update on confirmation with progress feedback
+
+#### Scenario: Downgrades disabled in the dialog
+
+- **WHEN** a listed version is older than the device's current supervisor version
+- **THEN** it is displayed as disabled with a "downgrade not allowed" hint

--- a/openspec/changes/add-supervisor-version-management/tasks.md
+++ b/openspec/changes/add-supervisor-version-management/tasks.md
@@ -1,0 +1,45 @@
+# Tasks
+
+## 1. Server — balenaCloud catalog client
+
+- [ ] 1.1 `server/controller/supervisorRelease/cloud.ts`: anonymous reads — app by slug `balena_os/<arch>-supervisor`, releases (status success, `$orderby=id desc`), `release_image`, `image` (location + content_hash + `is_a_build_of__service` expand), service names; typed errors; env `BALENACLOUD_API_URL` default `https://api.balena-cloud.com`
+- [ ] 1.2 Version normalization: dedupe by `semver` (keep newest raw per semver), order semver-desc with `balena-semver`
+
+## 2. Server — instance seeding (idempotent)
+
+- [ ] 2.1 `server/controller/supervisorRelease/instance.ts`: read instance state with the forwarded JWT — existing supervisor apps by slug, releases by (app, semver), services by name, images by content_hash
+- [ ] 2.2 `server/controller/supervisorRelease/seed.ts`: create-if-missing in crash-safe order: app (`<arch>-supervisor`, public, non-host, `is_for__device_type` = an instance device type of that arch) → services → images (instance-registry location, balenaCloud content_hash) → **mirror blobs** → release (`raw_version`=semver, semver fields, `status: 'success'`, `is_final: true`, composition copied) → `release_image` links; per-(arch, version) in-process lock; device-type→arch resolution via instance `device_type` expand `is_of__cpu_architecture`
+- [ ] 2.3 Use the same endpoint path style and resource names the UI's dataProvider uses (read `src/dataProvider/index.ts`); all writes with the caller's forwarded `Authorization` header
+
+## 3. Server — registry mirroring
+
+- [ ] 3.1 `server/controller/supervisorRelease/registryMirror.ts`: source token (`{BC}/auth/v1/token` with `BALENACLOUD_TOKEN`), target token (instance `/auth/v1/token` with caller JWT, scope `repository:<repo>:pull,push`); registry host from `OPEN_BALENA_REGISTRY_URL` or derived (`api.` → `registry2.`)
+- [ ] 3.2 Copy: manifest by digest byte-identical (Accept: docker v2/v2-list + OCI manifest/index), recurse referenced manifests/config/layers; HEAD-check target blob existence, stream through (no full-image buffering); idempotent by digest
+- [ ] 3.3 Clear typed error when `BALENACLOUD_TOKEN` is unset ("mirroring not configured") — listing must keep working without it
+
+## 4. Server — routes
+
+- [ ] 4.1 `server/routes/supervisorRelease.ts` (conventions of `registryImage.ts`; `dosProtect` + `authorize`): `GET /supervisor-releases/versions?deviceType=`, `GET /supervisor-releases/status?deviceId=`, `POST /supervisor-releases/seed {deviceType, version}`, `POST /supervisor-releases/update {deviceType, version, deviceIds[]}` (ensures seeded; per-device PATCH results; bulk tolerates partial failure)
+- [ ] 4.2 Mount in `server/index.ts` before the static catch-all
+
+## 5. Frontend — API client + dialog
+
+- [ ] 5.1 `src/lib/supervisorRelease.ts`: typed client for the four routes (JWT from the same source the dataProvider uses)
+- [ ] 5.2 `src/ui/SupervisorUpdateDialog.tsx`: version list (current version marked; older versions disabled with "downgrade not allowed" hint), seed phases feedback (metadata → mirroring → applying), per-device results for bulk, "mirroring not configured" Alert, error surfacing
+- [ ] 5.3 Device dashboard supervisor card: show current supervisor version + target (if `should be managed by-release` set — respect `src/versions/index.ts` field mappings) and an "Update Supervisor" button opening the dialog
+
+## 6. Frontend — bulk actions
+
+- [ ] 6.1 Device list bulk action "Update Supervisor" (validate same device type across selection)
+- [ ] 6.2 Fleet page action: update supervisor for all devices of the fleet (grouped by device type client-side)
+
+## 7. Tests
+
+- [ ] 7.1 `tests/supervisorRelease/*.test.ts` (`node:test`, mocked fetch, no network): version dedup/order, device-type→arch→app-slug mapping, registry host derivation, mirror plan (manifest → blob set, list recursion) against fixture manifests, seed idempotency decision logic, downgrade pre-filter for UI list, bulk result aggregation
+- [ ] 7.2 `npm test` script + CI wiring (if not already present from the OS-image change)
+
+## 8. Docs & verification
+
+- [ ] 8.1 README: feature section + env vars `BALENACLOUD_TOKEN`, `OPEN_BALENA_REGISTRY_URL` (+ `BALENACLOUD_API_URL` if new)
+- [ ] 8.2 Gates: `npm run typecheck`, `npm test`, `npm run prettier`, `npm run build` all clean; boot the built server and verify routes respond 401 unauthenticated
+- [ ] 8.3 Live read-only smoke: anonymous balenaCloud catalog queries for a real arch return versions; instance `device_type` arch resolution works with a forwarded token (no writes)

--- a/openspec/changes/add-supervisor-version-management/tasks.md
+++ b/openspec/changes/add-supervisor-version-management/tasks.md
@@ -2,31 +2,53 @@
 
 ## 1. Server — balenaCloud catalog client
 
-- [ ] 1.1 `server/controller/supervisorRelease/cloud.ts`: anonymous reads — app by slug `balena_os/<arch>-supervisor`, releases (status success, `$orderby=id desc`), `release_image`, `image` (location + content_hash + `is_a_build_of__service` expand), service names; typed errors; env `BALENACLOUD_API_URL` default `https://api.balena-cloud.com`
+- [ ] 1.1 `server/controller/supervisorRelease/cloud.ts`: anonymous reads — app by slug `balena_os/<arch>-supervisor`,
+      releases (status success, `$orderby=id desc`), `release_image`, `image` (location + content_hash +
+      `is_a_build_of__service` expand), service names; typed errors; env `BALENACLOUD_API_URL` default
+      `https://api.balena-cloud.com`
 - [ ] 1.2 Version normalization: dedupe by `semver` (keep newest raw per semver), order semver-desc with `balena-semver`
 
 ## 2. Server — instance seeding (idempotent)
 
-- [ ] 2.1 `server/controller/supervisorRelease/instance.ts`: read instance state with the forwarded JWT — existing supervisor apps by slug, releases by (app, semver), services by name, images by content_hash
-- [ ] 2.2 `server/controller/supervisorRelease/seed.ts`: create-if-missing in crash-safe order: app (`<arch>-supervisor`, public, non-host, `is_for__device_type` = an instance device type of that arch) → services → images (instance-registry location, balenaCloud content_hash) → **mirror blobs** → release (`raw_version`=semver, semver fields, `status: 'success'`, `is_final: true`, composition copied) → `release_image` links; per-(arch, version) in-process lock; device-type→arch resolution via instance `device_type` expand `is_of__cpu_architecture`
-- [ ] 2.3 Use the same endpoint path style and resource names the UI's dataProvider uses (read `src/dataProvider/index.ts`); all writes with the caller's forwarded `Authorization` header
+- [ ] 2.1 `server/controller/supervisorRelease/instance.ts`: read instance state with the forwarded JWT — existing
+      supervisor apps by slug, releases by (app, semver), services by name, images by content_hash
+- [ ] 2.2 `server/controller/supervisorRelease/seed.ts`: create-if-missing in crash-safe order: app
+      (`<arch>-supervisor`, public, non-host, `is_for__device_type` = an instance device type of that arch) → services →
+      images (instance-registry location, balenaCloud content_hash) → **mirror blobs** → release (`raw_version`=semver,
+      semver fields, `status: 'success'`, `is_final: true`, composition copied) → `release_image` links; per-(arch,
+      version) in-process lock; device-type→arch resolution via instance `device_type` expand `is_of__cpu_architecture`
+- [ ] 2.3 Use the same endpoint path style and resource names the UI's dataProvider uses (read
+      `src/dataProvider/index.ts`); all writes with the caller's forwarded `Authorization` header
 
 ## 3. Server — registry mirroring
 
-- [ ] 3.1 `server/controller/supervisorRelease/registryMirror.ts`: source token (`{BC}/auth/v1/token` with `BALENACLOUD_TOKEN`), target token (instance `/auth/v1/token` with caller JWT, scope `repository:<repo>:pull,push`); registry host from `OPEN_BALENA_REGISTRY_URL` or derived (`api.` → `registry2.`)
-- [ ] 3.2 Copy: manifest by digest byte-identical (Accept: docker v2/v2-list + OCI manifest/index), recurse referenced manifests/config/layers; HEAD-check target blob existence, stream through (no full-image buffering); idempotent by digest
-- [ ] 3.3 Clear typed error when `BALENACLOUD_TOKEN` is unset ("mirroring not configured") — listing must keep working without it
+- [ ] 3.1 `server/controller/supervisorRelease/registryMirror.ts`: source token (`{BC}/auth/v1/token` with
+      `BALENACLOUD_TOKEN`), target token (instance `/auth/v1/token` with caller JWT, scope
+      `repository:<repo>:pull,push`); registry host from `OPEN_BALENA_REGISTRY_URL` or derived (`api.` → `registry2.`)
+- [ ] 3.2 Copy: manifest by digest byte-identical (Accept: docker v2/v2-list + OCI manifest/index), recurse referenced
+      manifests/config/layers; HEAD-check target blob existence, stream through (no full-image buffering); idempotent by
+      digest
+- [ ] 3.3 Clear typed error when `BALENACLOUD_TOKEN` is unset ("mirroring not configured") — listing must keep working
+      without it
 
 ## 4. Server — routes
 
-- [ ] 4.1 `server/routes/supervisorRelease.ts` (conventions of `registryImage.ts`; `dosProtect` + `authorize`): `GET /supervisor-releases/versions?deviceType=`, `GET /supervisor-releases/status?deviceId=`, `POST /supervisor-releases/seed {deviceType, version}`, `POST /supervisor-releases/update {deviceType, version, deviceIds[]}` (ensures seeded; per-device PATCH results; bulk tolerates partial failure)
+- [ ] 4.1 `server/routes/supervisorRelease.ts` (conventions of `registryImage.ts`; `dosProtect` + `authorize`):
+      `GET /supervisor-releases/versions?deviceType=`, `GET /supervisor-releases/status?deviceId=`,
+      `POST /supervisor-releases/seed {deviceType, version}`,
+      `POST /supervisor-releases/update {deviceType, version, deviceIds[]}` (ensures seeded; per-device PATCH results;
+      bulk tolerates partial failure)
 - [ ] 4.2 Mount in `server/index.ts` before the static catch-all
 
 ## 5. Frontend — API client + dialog
 
-- [ ] 5.1 `src/lib/supervisorRelease.ts`: typed client for the four routes (JWT from the same source the dataProvider uses)
-- [ ] 5.2 `src/ui/SupervisorUpdateDialog.tsx`: version list (current version marked; older versions disabled with "downgrade not allowed" hint), seed phases feedback (metadata → mirroring → applying), per-device results for bulk, "mirroring not configured" Alert, error surfacing
-- [ ] 5.3 Device dashboard supervisor card: show current supervisor version + target (if `should be managed by-release` set — respect `src/versions/index.ts` field mappings) and an "Update Supervisor" button opening the dialog
+- [ ] 5.1 `src/lib/supervisorRelease.ts`: typed client for the four routes (JWT from the same source the dataProvider
+      uses)
+- [ ] 5.2 `src/ui/SupervisorUpdateDialog.tsx`: version list (current version marked; older versions disabled with
+      "downgrade not allowed" hint), seed phases feedback (metadata → mirroring → applying), per-device results for
+      bulk, "mirroring not configured" Alert, error surfacing
+- [ ] 5.3 Device dashboard supervisor card: show current supervisor version + target (if `should be managed by-release`
+      set — respect `src/versions/index.ts` field mappings) and an "Update Supervisor" button opening the dialog
 
 ## 6. Frontend — bulk actions
 
@@ -35,11 +57,17 @@
 
 ## 7. Tests
 
-- [ ] 7.1 `tests/supervisorRelease/*.test.ts` (`node:test`, mocked fetch, no network): version dedup/order, device-type→arch→app-slug mapping, registry host derivation, mirror plan (manifest → blob set, list recursion) against fixture manifests, seed idempotency decision logic, downgrade pre-filter for UI list, bulk result aggregation
+- [ ] 7.1 `tests/supervisorRelease/*.test.ts` (`node:test`, mocked fetch, no network): version dedup/order,
+      device-type→arch→app-slug mapping, registry host derivation, mirror plan (manifest → blob set, list recursion)
+      against fixture manifests, seed idempotency decision logic, downgrade pre-filter for UI list, bulk result
+      aggregation
 - [ ] 7.2 `npm test` script + CI wiring (if not already present from the OS-image change)
 
 ## 8. Docs & verification
 
-- [ ] 8.1 README: feature section + env vars `BALENACLOUD_TOKEN`, `OPEN_BALENA_REGISTRY_URL` (+ `BALENACLOUD_API_URL` if new)
-- [ ] 8.2 Gates: `npm run typecheck`, `npm test`, `npm run prettier`, `npm run build` all clean; boot the built server and verify routes respond 401 unauthenticated
-- [ ] 8.3 Live read-only smoke: anonymous balenaCloud catalog queries for a real arch return versions; instance `device_type` arch resolution works with a forwarded token (no writes)
+- [ ] 8.1 README: feature section + env vars `BALENACLOUD_TOKEN`, `OPEN_BALENA_REGISTRY_URL` (+ `BALENACLOUD_API_URL` if
+      new)
+- [ ] 8.2 Gates: `npm run typecheck`, `npm test`, `npm run prettier`, `npm run build` all clean; boot the built server
+      and verify routes respond 401 unauthenticated
+- [ ] 8.3 Live read-only smoke: anonymous balenaCloud catalog queries for a real arch return versions; instance
+      `device_type` arch resolution works with a forwarded token (no writes)

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -1,0 +1,31 @@
+# OpenSpec Project Context
+
+## Why
+
+This project provides `open-balena-ui`: a web UI (react-admin) with a small companion Express server for administering
+an openBalena instance — fleets, devices, releases, users, and registry maintenance.
+
+## What Changes
+
+Changes are managed as OpenSpec change proposals under `openspec/changes/`.
+
+## Capability
+
+`open-balena-ui` is a single product: a TypeScript Express server (`server/`) that serves the built client
+(`dist/client`) and exposes authenticated JSON routes, plus a react-admin SPA (`src/`) that talks to openBalena's OData
+API and the UI server routes.
+
+## Quality
+
+- Code is formatted with Prettier (`npm run prettier`) and type-checked with `npm run typecheck`.
+- Tests use Node's built-in `node:test` runner via `tsx` (no additional test dependencies).
+- New server routes follow the existing pattern: `server/routes/<name>.ts` + `server/controller/<name>/`, guarded by
+  `authorize` (JWT, `OPEN_BALENA_JWT_SECRET`) and `dosProtect`.
+- The server bundle is produced with `ncc` (`npm run build:server`); changes must keep that build working, including
+  native module assets.
+
+## Risks
+
+- The upstream openBalena API evolves; field/name drift is handled via `src/versions/index.ts` mappings.
+- balenaCloud public endpoints (version listing, image download) are external dependencies and must be proxied
+  server-side, never directly from the browser.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-balena-ui",
-  "version": "0.5.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-balena-ui",
-      "version": "0.5.0",
+      "version": "0.7.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.913.0",
         "@emotion/react": "^11.14.0",
@@ -15,6 +15,7 @@
         "@mui/material": "^6.5.0",
         "assert": "^2.1.0",
         "axios": "^1.12.2",
+        "balena-semver": "^4.1.12",
         "base32-encode": "^2.0.0",
         "bcrypt-ts": "^7.1.0",
         "buffer": "^6.0.3",
@@ -3712,18 +3713,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@jridgewell/source-map": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
-      "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -5488,6 +5477,12 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "node_modules/@types/memoizee": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/@types/memoizee/-/memoizee-0.4.12.tgz",
+      "integrity": "sha512-EdtpwNYNhe3kZ+4TlXj/++pvBoU0KdrAICMzgI7vjWgu9sIvvUhu9XR8Ks4L6Wh3sxpZ22wkZR7yCLAqUjnZuQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -5565,8 +5560,7 @@
     "node_modules/@types/semver": {
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.0.tgz",
-      "integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==",
-      "dev": true
+      "integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA=="
     },
     "node_modules/@types/send": {
       "version": "0.17.4",
@@ -6276,6 +6270,21 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/balena-semver": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/balena-semver/-/balena-semver-4.1.12.tgz",
+      "integrity": "sha512-hSI+UQCiD+7t1epbQgxAO9YtFJ0MgkSjYGEbh5kNgrU4NaWSw8Twvxc8FJDoIH56b+vrqwrFzjITFLSWyteEJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/memoizee": "^0.4.12",
+        "@types/semver": "^7.7.0",
+        "memoizee": "^0.4.17",
+        "semver": "^7.7.2"
+      },
+      "engines": {
+        "node": "^20.12.0 || >= 22.0.0"
+      }
+    },
     "node_modules/base32-encode": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/base32-encode/-/base32-encode-2.0.0.tgz",
@@ -6434,14 +6443,6 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
       }
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -6715,6 +6716,19 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/d": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
+      "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
+      "license": "ISC",
+      "dependencies": {
+        "es5-ext": "^0.10.64",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -7142,6 +7156,58 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es5-ext": {
+      "version": "0.10.64",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
+      "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
+      "hasInstallScript": true,
+      "license": "ISC",
+      "dependencies": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+      "license": "MIT",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/es6-symbol": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
+      "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.2",
+        "ext": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/es6-weak-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "license": "ISC",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
       }
     },
     "node_modules/esbuild": {
@@ -7678,6 +7744,21 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/esniff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.62",
+        "event-emitter": "^0.3.5",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/espree": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
@@ -7746,6 +7827,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+      "license": "MIT",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "node_modules/eventemitter3": {
@@ -7869,6 +7960,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/ext": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+      "license": "ISC",
+      "dependencies": {
+        "type": "^2.7.2"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -9184,6 +9284,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lru-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+      "integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es5-ext": "~0.10.2"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -9200,6 +9309,31 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/memoizee": {
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.17.tgz",
+      "integrity": "sha512-DGqD7Hjpi/1or4F/aYAspXKNm5Yili0QDAFAY4QYvpqpgiY6+1jOfqpmByzjxbWd/T9mChbCArXAbDAsTm5oXA==",
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.2",
+        "es5-ext": "^0.10.64",
+        "es6-weak-map": "^2.0.3",
+        "event-emitter": "^0.3.5",
+        "is-promise": "^2.2.2",
+        "lru-queue": "^0.1.0",
+        "next-tick": "^1.1.0",
+        "timers-ext": "^0.1.7"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/memoizee/node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "license": "MIT"
     },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
@@ -9344,6 +9478,12 @@
       "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
+    },
+    "node_modules/next-tick": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+      "license": "ISC"
     },
     "node_modules/node-polyglot": {
       "version": "2.6.0",
@@ -10869,29 +11009,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/source-map-support/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/split-on-first": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-3.0.0.tgz",
@@ -11096,40 +11213,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/terser": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
-      "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.8.2",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/terser/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/timers-ext": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.8.tgz",
+      "integrity": "sha512-wFH7+SEAcKfJpfLPkrgMPvvwnEtj8W4IurvEyrKsDleXnKLCDw71w8jltvfLa8Rm4qQxxT4jmDBYbJG/z7qoww==",
+      "license": "ISC",
+      "dependencies": {
+        "es5-ext": "^0.10.64",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
@@ -11276,6 +11378,12 @@
       "optionalDependencies": {
         "fsevents": "~2.3.3"
       }
+    },
+    "node_modules/type": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
+      "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
+      "license": "ISC"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@mui/material": "^6.5.0",
     "assert": "^2.1.0",
     "axios": "^1.12.2",
+    "balena-semver": "^4.1.12",
     "base32-encode": "^2.0.0",
     "bcrypt-ts": "^7.1.0",
     "buffer": "^6.0.3",
@@ -73,7 +74,8 @@
     "build:server": "ncc build server/index.ts -o dist/server -m",
     "preview": "vite preview --outDir dist/client",
     "typecheck": "tsc --noEmit",
-    "prettier": "prettier --write ."
+    "prettier": "prettier --write .",
+    "test": "tsx --test tests/supervisorRelease/*.test.ts"
   },
   "eslintConfig": {
     "extends": [

--- a/server/controller/supervisorRelease/cloud.ts
+++ b/server/controller/supervisorRelease/cloud.ts
@@ -1,0 +1,180 @@
+import * as balenaSemver from 'balena-semver';
+import { UpstreamError } from './errors';
+
+/**
+ * Anonymous read-only client for balenaCloud's public supervisor catalog.
+ *
+ * OData encoding note (verified against api.balena-cloud.com): spaces in the
+ * query string are encoded as `%20` exactly once; single quotes, slashes and
+ * `$`-prefixed options must stay literal — percent-encoded quotes are rejected
+ * with `400 Malformed url`. Only ever interpolate values that passed
+ * `isSafeODataToken` below into a filter string.
+ */
+
+export const DEFAULT_BALENACLOUD_API_URL = 'https://api.balena-cloud.com';
+
+export const balenaCloudApiUrl = (): string =>
+  (process.env.BALENACLOUD_API_URL || DEFAULT_BALENACLOUD_API_URL).replace(/\/+$/, '');
+
+/** BalenaCloud slug of the supervisor fleet application for a CPU arch slug (e.g. `aarch64`). */
+export const supervisorAppSlug = (arch: string): string => `balena_os/${arch}-supervisor`;
+
+/** Restricts a value to characters that are safe unencoded inside an OData $filter literal. */
+export const isSafeODataToken = (value: string): boolean => /^[a-zA-Z0-9][a-zA-Z0-9._+-]*$/.test(value);
+
+export interface CloudApplication {
+  id: number;
+  slug: string;
+}
+
+export interface CloudRelease {
+  id: number;
+  raw_version: string;
+  semver: string;
+  variant: string;
+  composition: unknown;
+}
+
+export interface CloudReleaseImage {
+  location: string;
+  contentHash: string;
+  serviceName: string;
+}
+
+/** A release after dedupe/ordering, ready for the version listing. */
+export interface CatalogVersion {
+  semver: string;
+  rawVersion: string;
+  cloudReleaseId: number;
+  variant: string;
+}
+
+interface ODataResponse<T> {
+  d: T[];
+}
+
+interface ExpandedCloudImage {
+  is_stored_at__image_location?: string;
+  content_hash?: string;
+  is_a_build_of__service?: { service_name?: string }[] | { service_name?: string } | null;
+}
+
+const asArray = <T>(value: T | T[] | null | undefined): T[] =>
+  value == null ? [] : Array.isArray(value) ? value : [value];
+
+const readJson = async (res: Response): Promise<unknown> => {
+  try {
+    return await res.json();
+  } catch {
+    return null;
+  }
+};
+
+const getCloudJson = async <T>(path: string): Promise<T[]> => {
+  const res = await fetch(`${balenaCloudApiUrl()}${path}`, {
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!res.ok) {
+    const body = await readJson(res);
+    const detail =
+      body && typeof body === 'object' && 'error' in body
+        ? `: ${String((body as { error: { text?: string } }).error?.text ?? '').slice(0, 200)}`
+        : '';
+    throw new UpstreamError(`balenaCloud request failed with status ${res.status}${detail}`);
+  }
+
+  const body = (await readJson(res)) as ODataResponse<T> | T[] | null;
+  if (body == null) {
+    return [];
+  }
+  return Array.isArray(body) ? body : body.d;
+};
+
+/** Fetch the public supervisor application for a CPU arch. Returns null when none exists. */
+export const fetchSupervisorApplication = async (arch: string): Promise<CloudApplication | null> => {
+  if (!isSafeODataToken(arch)) {
+    throw new UpstreamError(`Invalid CPU architecture: ${arch}`);
+  }
+
+  const apps = await getCloudJson<CloudApplication>(
+    `/v6/application?$select=id,slug,app_name&$filter=slug%20eq%20'${supervisorAppSlug(arch)}'`,
+  );
+
+  return apps[0] ?? null;
+};
+
+/**
+ * All successful releases of a supervisor application, newest first
+ * (`$orderby=id desc`), top 1000.
+ */
+export const fetchSupervisorReleases = async (applicationId: number): Promise<CloudRelease[]> =>
+  getCloudJson<CloudRelease>(
+    `/v6/release?$select=id,raw_version,semver,composition,variant` +
+      `&$filter=belongs_to__application%20eq%20${applicationId}%20and%20status%20eq%20'success'` +
+      `&$orderby=id%20desc&$top=1000`,
+  );
+
+/**
+ * Images of one cloud release in a single expanded query. Expanded navigations
+ * resolve to arrays; `is_a_build_of__service` carries the service name.
+ */
+export const fetchReleaseImages = async (releaseId: number): Promise<CloudReleaseImage[]> => {
+  const rows = await getCloudJson<{ image: ExpandedCloudImage | ExpandedCloudImage[] }>(
+    `/v6/release_image?$select=image&$filter=release%20eq%20${releaseId}` +
+      `&$expand=image($select=is_stored_at__image_location,content_hash;` +
+      `$expand=is_a_build_of__service($select=service_name))`,
+  );
+
+  const images: CloudReleaseImage[] = [];
+  for (const row of rows) {
+    for (const image of asArray(row.image)) {
+      const service = asArray(image.is_a_build_of__service)[0] ?? image.is_a_build_of__service ?? undefined;
+      const serviceName =
+        service && !Array.isArray(service) ? (service.service_name ?? '') : (service?.service_name ?? '');
+
+      if (image.is_stored_at__image_location && image.content_hash) {
+        images.push({
+          location: image.is_stored_at__image_location,
+          contentHash: image.content_hash,
+          serviceName,
+        });
+      }
+    }
+  }
+
+  return images;
+};
+
+/** The verbatim balenaCloud release composition (copied into seeded releases). */
+export const fetchCloudReleaseComposition = async (releaseId: number): Promise<unknown> => {
+  const rows = await getCloudJson<{ composition?: unknown }>(`/v6/release(${releaseId})?$select=composition`);
+  return rows[0]?.composition ?? {};
+};
+
+/**
+ * Dedupe releases by semver, keeping the newest raw_version per semver
+ * (releases arrive newest-first, so the first occurrence wins), and order the
+ * result semver-descending using balena-semver. Pure — unit tested.
+ */
+export const dedupeAndOrderReleases = (releases: CloudRelease[]): CatalogVersion[] => {
+  const bySemver = new Map<string, CatalogVersion>();
+  for (const release of releases) {
+    if (!release.semver || !release.raw_version) {
+      continue;
+    }
+    if (!bySemver.has(release.semver)) {
+      bySemver.set(release.semver, {
+        semver: release.semver,
+        rawVersion: release.raw_version,
+        cloudReleaseId: release.id,
+        variant: release.variant ?? '',
+      });
+    }
+  }
+
+  return [...bySemver.values()].sort((a, b) => balenaSemver.rcompare(a.semver, b.semver));
+};
+
+/** balena-semver comparison helper usable from both server and client code. */
+export const compareSupervisorVersions = (left: string, right: string): number => balenaSemver.compare(left, right);

--- a/server/controller/supervisorRelease/errors.ts
+++ b/server/controller/supervisorRelease/errors.ts
@@ -1,0 +1,51 @@
+/**
+ * Typed errors for the supervisor release feature.
+ * Routes map these to HTTP responses with the `{ success: false, message }` shape
+ * used by the other UI server routes.
+ */
+
+/** balenaCloud (catalog or registry) could not be read from / copied from. */
+export class UpstreamError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UpstreamError';
+  }
+}
+
+/** A requested entity (device type, supervisor version, ...) does not exist. */
+export class NotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'NotFoundError';
+  }
+}
+
+/** The openBalena instance API returned an unexpected response. */
+export class InstanceApiError extends Error {
+  public readonly status: number;
+
+  constructor(message: string, status = 502) {
+    super(message);
+    this.name = 'InstanceApiError';
+    this.status = status;
+  }
+}
+
+/** `BALENACLOUD_TOKEN` is not configured: listing works, seeding/mirroring cannot. */
+export class MirroringNotConfiguredError extends Error {
+  constructor() {
+    super(
+      'Supervisor image mirroring is not configured: set the BALENACLOUD_TOKEN environment variable ' +
+        '(a balenaCloud JWT with registry pull access) on the open-balena-ui server.',
+    );
+    this.name = 'MirroringNotConfiguredError';
+  }
+}
+
+/** The instance registry rejected or failed a mirror operation. */
+export class RegistryMirrorError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RegistryMirrorError';
+  }
+}

--- a/server/controller/supervisorRelease/index.ts
+++ b/server/controller/supervisorRelease/index.ts
@@ -1,0 +1,21 @@
+import * as cloud from './cloud';
+import * as instance from './instance';
+import * as registryMirror from './registryMirror';
+import * as seed from './seed';
+import * as update from './update';
+
+export { cloud, instance, registryMirror, seed, update };
+export * from './errors';
+export * from './cloud';
+export * from './instance';
+export * from './registryMirror';
+export * from './seed';
+export * from './update';
+
+export default {
+  cloud,
+  instance,
+  registryMirror,
+  seed,
+  update,
+};

--- a/server/controller/supervisorRelease/instance.ts
+++ b/server/controller/supervisorRelease/instance.ts
@@ -1,0 +1,530 @@
+import { createHash } from 'node:crypto';
+import { InstanceApiError, NotFoundError } from './errors';
+import { supervisorAppSlug } from './cloud';
+
+/**
+ * Reads/writes against the user's openBalena instance, always with the
+ * caller's forwarded `Authorization` header. Endpoint paths mirror the
+ * instance's v6 (pine) API — the same resource names the dataProvider uses
+ * (`application`, `release`, `release_image`, `device`, …) — because writes
+ * (e.g. the device supervisor-release PATCH) must run the instance's pine
+ * hooks.
+ */
+
+export interface InstanceAuth {
+  authorization: string;
+}
+
+export interface DeviceTypeInfo {
+  id: number;
+  slug: string;
+  arch: string;
+}
+
+export interface InstanceRelease {
+  id: number;
+  rawVersion: string;
+  semver: string | null;
+}
+
+export interface InstanceImage {
+  id: number;
+  serviceId: number;
+  location: string;
+  contentHash: string;
+}
+
+export interface CreateReleaseInput {
+  appId: number;
+  commit: string;
+  rawVersion: string;
+  semver: SemverFields;
+  composition: unknown;
+}
+
+export interface SemverFields {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string;
+  build: string;
+}
+
+export const instanceApiUrl = (): string => {
+  const url = process.env.REACT_APP_OPEN_BALENA_API_URL;
+  if (!url) {
+    throw new InstanceApiError('REACT_APP_OPEN_BALENA_API_URL is not configured on the server', 500);
+  }
+  return url.replace(/\/+$/, '');
+};
+
+const asArray = <T>(value: T | T[] | null | undefined): T[] =>
+  value == null ? [] : Array.isArray(value) ? value : [value];
+
+const extractErrorMessage = async (res: Response, fallback: string): Promise<string> => {
+  try {
+    const body = (await res.json()) as unknown;
+    if (body && typeof body === 'object') {
+      const anyBody = body as Record<string, unknown>;
+      // pine error shape: { error: { text } } / { message } / plain string bodies
+      const error = anyBody.error;
+      if (error && typeof error === 'object' && 'text' in error && typeof error.text === 'string') {
+        return error.text;
+      }
+      if (typeof anyBody.message === 'string') {
+        return anyBody.message;
+      }
+      if (typeof error === 'string') {
+        return error;
+      }
+    }
+    if (typeof body === 'string') {
+      return body.slice(0, 300);
+    }
+  } catch {
+    // fall through to the fallback
+  }
+  return fallback;
+};
+
+const instanceFetch = async (auth: InstanceAuth, path: string, init?: RequestInit): Promise<Response> => {
+  const res = await fetch(`${instanceApiUrl()}${path}`, {
+    ...init,
+    headers: {
+      Accept: 'application/json',
+      ...(init?.body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.headers as Record<string, string> | undefined),
+      Authorization: auth.authorization,
+    },
+  });
+  return res;
+};
+
+const odataGet = async <T>(auth: InstanceAuth, path: string): Promise<T[]> => {
+  const res = await instanceFetch(auth, path);
+  if (!res.ok) {
+    throw new InstanceApiError(await extractErrorMessage(res, `Instance request failed (${res.status})`));
+  }
+  const body = (await res.json()) as { d?: T[] } | T[];
+  return Array.isArray(body) ? body : (body.d ?? []);
+};
+
+const odataPost = async <T extends { id: number }>(
+  auth: InstanceAuth,
+  resource: string,
+  data: Record<string, unknown>,
+): Promise<T> => {
+  const res = await instanceFetch(auth, `/v6/${resource}`, {
+    method: 'POST',
+    headers: { Prefer: 'return=representation' },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) {
+    throw new InstanceApiError(await extractErrorMessage(res, `Instance create of ${resource} failed (${res.status})`));
+  }
+  const body: unknown = await res.json();
+  if (Array.isArray(body)) {
+    const rows = (body as { d?: T[] }).d ?? [];
+    if (!rows[0]) {
+      throw new InstanceApiError(`Instance create of ${resource} returned no row`);
+    }
+    return rows[0];
+  }
+  return body as T;
+};
+
+const odataPatch = async (auth: InstanceAuth, path: string, data: Record<string, unknown>): Promise<Response> =>
+  instanceFetch(auth, path, { method: 'PATCH', body: JSON.stringify(data) });
+
+// ---------------------------------------------------------------------------
+// Field-name compatibility probes (cache per process)
+// ---------------------------------------------------------------------------
+
+const releaseFieldCache = new Map<string, boolean>();
+
+/**
+ * Probe whether the instance's release resource supports a field (e.g.
+ * `raw_version` vs the newer `release_version`, `is_final`). Uses a $select on
+ * the resource: unknown fields are rejected with 400 regardless of row count.
+ */
+export const releaseSupportsField = async (auth: InstanceAuth, field: string): Promise<boolean> => {
+  const cached = releaseFieldCache.get(field);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const res = await instanceFetch(auth, `/v6/release?$select=${field}&$top=1`);
+  const supported = res.ok;
+  releaseFieldCache.set(field, supported);
+  return supported;
+};
+
+/** The instance's name for the raw version column of `release`. */
+export const releaseVersionField = async (auth: InstanceAuth): Promise<'raw_version' | 'release_version'> =>
+  (await releaseSupportsField(auth, 'raw_version')) ? 'raw_version' : 'release_version';
+
+// ---------------------------------------------------------------------------
+// Device type / arch resolution
+// ---------------------------------------------------------------------------
+
+/** Resolve a device type slug to its id and CPU arch slug via the instance. */
+export const getDeviceTypeBySlug = async (auth: InstanceAuth, slug: string): Promise<DeviceTypeInfo> => {
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(slug)) {
+    throw new NotFoundError(`Invalid device type slug: ${slug}`);
+  }
+
+  interface Row {
+    id: number;
+    slug: string;
+    is_of__cpu_architecture?: { slug?: string }[] | { slug?: string } | null;
+  }
+
+  const rows = await odataGet<Row>(
+    auth,
+    `/v6/device_type?$filter=slug%20eq%20'${slug}'&$select=id,slug&$expand=is_of__cpu_architecture($select=slug)`,
+  );
+  const row = rows[0];
+  if (!row) {
+    throw new NotFoundError(`Unknown device type: ${slug}`);
+  }
+
+  const arch = asArray(row.is_of__cpu_architecture)[0]?.slug;
+  if (!arch) {
+    throw new InstanceApiError(`Device type ${slug} has no CPU architecture on the instance`);
+  }
+
+  return { id: row.id, slug: row.slug, arch };
+};
+
+/** Find any instance device type for a CPU arch slug (first by id) — used for app creation. */
+export const findDeviceTypeByArch = async (auth: InstanceAuth, arch: string): Promise<DeviceTypeInfo> => {
+  interface Row {
+    id: number;
+    slug: string;
+    is_of__cpu_architecture?: { slug?: string }[] | { slug?: string } | null;
+  }
+
+  const rows = await odataGet<Row>(
+    auth,
+    `/v6/device_type?$select=id,slug,is_of__cpu_architecture&$expand=is_of__cpu_architecture($select=slug)` +
+      `&$orderby=id%20asc&$top=1000`,
+  );
+
+  const match = rows.find((row) => asArray(row.is_of__cpu_architecture)[0]?.slug === arch);
+  if (!match) {
+    throw new NotFoundError(`The instance has no device type for CPU architecture ${arch}`);
+  }
+
+  return { id: match.id, slug: match.slug, arch };
+};
+
+// ---------------------------------------------------------------------------
+// Supervisor application / services / images / releases
+// ---------------------------------------------------------------------------
+
+/** Look up an existing supervisor application by its exact slug. */
+export const findApplicationBySlug = async (auth: InstanceAuth, slug: string): Promise<{ id: number } | null> => {
+  if (!/^[a-zA-Z0-9_][a-zA-Z0-9_/-]*$/.test(slug)) {
+    throw new InstanceApiError(`Invalid application slug: ${slug}`);
+  }
+  const rows = await odataGet<{ id: number }>(auth, `/v6/application?$select=id&$filter=slug%20eq%20'${slug}'&$top=1`);
+  return rows[0] ?? null;
+};
+
+/** All releases of an application (id, raw version, semver). */
+export const findAppReleases = async (auth: InstanceAuth, appId: number): Promise<InstanceRelease[]> => {
+  const versionField = await releaseVersionField(auth);
+  const rows = await odataGet<{ id: number; raw_version?: string; release_version?: string; semver?: string }>(
+    auth,
+    `/v6/release?$select=id,${versionField},semver&$filter=belongs_to__application%20eq%20${appId}` +
+      `&$orderby=id%20desc&$top=1000`,
+  );
+
+  return rows.map((row) => ({
+    id: row.id,
+    rawVersion: (versionField === 'raw_version' ? row.raw_version : row.release_version) ?? '',
+    semver: row.semver ?? null,
+  }));
+};
+
+/** Look up a service of an application by name. */
+export const findServiceByName = async (
+  auth: InstanceAuth,
+  appId: number,
+  serviceName: string,
+): Promise<{ id: number } | null> => {
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9_.-]*$/.test(serviceName)) {
+    throw new InstanceApiError(`Invalid service name: ${serviceName}`);
+  }
+  const rows = await odataGet<{ id: number }>(
+    auth,
+    `/v6/service?$select=id&$filter=application%20eq%20${appId}%20and%20service_name%20eq%20'${serviceName}'&$top=1`,
+  );
+  return rows[0] ?? null;
+};
+
+/** Look up an image by content hash (globally unique per registry digest). */
+export const findImageByContentHash = async (
+  auth: InstanceAuth,
+  contentHash: string,
+): Promise<InstanceImage | null> => {
+  if (!/^sha256:[a-f0-9]{64}$/.test(contentHash)) {
+    throw new InstanceApiError(`Invalid content hash: ${contentHash}`);
+  }
+  const rows = await odataGet<{
+    id: number;
+    is_a_build_of__service?: { __id?: number } | { __id?: number }[] | number | null;
+    is_stored_at__image_location?: string;
+    content_hash?: string;
+  }>(
+    auth,
+    `/v6/image?$select=id,is_a_build_of__service,is_stored_at__image_location,content_hash` +
+      `&$filter=content_hash%20eq%20'${contentHash}'&$top=1`,
+  );
+
+  const row = rows[0];
+  if (!row) {
+    return null;
+  }
+
+  const service = asArray(row.is_a_build_of__service)[0];
+  const serviceId =
+    service && typeof service === 'object' && '__id' in service
+      ? (service.__id as number)
+      : typeof service === 'number'
+        ? service
+        : 0;
+
+  return {
+    id: row.id,
+    serviceId,
+    location: row.is_stored_at__image_location ?? '',
+    contentHash: row.content_hash ?? contentHash,
+  };
+};
+
+/** Look up release↔image links of a release. */
+export const findReleaseImages = async (auth: InstanceAuth, releaseId: number): Promise<{ imageId: number }[]> => {
+  const rows = await odataGet<{ image: { __id?: number } | { __id?: number }[] | number }>(
+    auth,
+    `/v6/release_image?$select=image&$filter=release%20eq%20${releaseId}&$top=1000`,
+  );
+
+  return rows
+    .map((row) => {
+      const image = asArray(row.image)[0];
+      if (image && typeof image === 'object' && '__id' in image) {
+        return { imageId: image.__id as number };
+      }
+      return typeof image === 'number' ? { imageId: image } : null;
+    })
+    .filter((entry): entry is { imageId: number } => entry !== null);
+};
+
+/** Parse a semver string into the release row's semver_* fields. Pure — unit tested. */
+export const parseSemverFields = (version: string): SemverFields => {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+([0-9A-Za-z.-]+))?$/.exec(version.trim());
+  if (!match) {
+    throw new InstanceApiError(`Invalid semver version: ${version}`);
+  }
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4] ?? '',
+    build: match[5] ?? '',
+  };
+};
+
+/**
+ * Deterministic commit for a seeded release derived from the balenaCloud
+ * release identity (open-balena-api caps commit at 40 chars).
+ */
+export const commitForCloudRelease = (cloudReleaseId: number, rawVersion: string): string =>
+  createHash('sha256').update(`${cloudReleaseId}:${rawVersion}`).digest('hex').slice(0, 40);
+
+/** Ensure an organization with the given handle exists; return its id. */
+export const ensureOrganization = async (auth: InstanceAuth, handle: string): Promise<number> => {
+  const rows = await odataGet<{ id: number }>(
+    auth,
+    `/v6/organization?$select=id&$filter=handle%20eq%20'${handle}'&$top=1`,
+  );
+  if (rows[0]) {
+    return rows[0].id;
+  }
+
+  const created = await odataPost<{ id: number }>(auth, 'organization', { name: handle, handle });
+  return created.id;
+};
+
+/** Resolve the application_type to use for supervisor apps (version-tolerant). */
+export const findSupervisorApplicationType = async (auth: InstanceAuth): Promise<number> => {
+  const rows = await odataGet<{ id: number; name: string; slug: string }>(
+    auth,
+    `/v6/application_type?$select=id,name,slug&$top=100`,
+  );
+
+  const preferred = rows.find((row) => row.slug === 'default') ?? rows.find((row) => row.name === 'App');
+  return preferred?.id ?? rows[0]?.id ?? 1;
+};
+
+/**
+ * Create the supervisor application for an arch. The instance generates
+ * `slug` as `<orgHandle>/<appName>` (and forces should_track_latest_release on
+ * POST), so this creates the `balena_os` organization when needed and PATCHes
+ * track-latest back to false afterwards. Callers must have checked
+ * `findApplicationBySlug` first for idempotency.
+ */
+export const createSupervisorApplication = async (
+  auth: InstanceAuth,
+  arch: string,
+  deviceTypeId: number,
+): Promise<{ id: number }> => {
+  const organizationId = await ensureOrganization(auth, 'balena_os');
+  const applicationType = await findSupervisorApplicationType(auth);
+  const appName = `${arch}-supervisor`;
+
+  const created = await odataPost<{ id: number; slug?: string }>(auth, 'application', {
+    app_name: appName,
+    organization: organizationId,
+    application_type: applicationType,
+    is_for__device_type: deviceTypeId,
+    is_host: false,
+    is_public: true,
+    should_track_latest_release: false,
+    is_of__class: 'app',
+  });
+
+  // The POST hook forces should_track_latest_release=true; supervisor fleets pin releases per-device.
+  await odataPatch(auth, `/v6/application(${created.id})`, { should_track_latest_release: false });
+
+  const app = (await odataGet<{ slug: string }>(auth, `/v6/application(${created.id})?$select=slug`))[0];
+  if (!app || app.slug !== supervisorAppSlug(arch)) {
+    throw new InstanceApiError(
+      `Created supervisor application has unexpected slug '${app?.slug ?? '<unknown>'}'` +
+        ` (expected '${supervisorAppSlug(arch)}')`,
+    );
+  }
+
+  return { id: created.id };
+};
+
+/** Create a service row. */
+export const createService = async (auth: InstanceAuth, appId: number, serviceName: string): Promise<{ id: number }> =>
+  odataPost<{ id: number }>(auth, 'service', {
+    application: appId,
+    service_name: serviceName,
+  });
+
+/** Create image metadata pointing at the instance registry location. */
+export const createImage = async (
+  auth: InstanceAuth,
+  serviceId: number,
+  location: string,
+  contentHash: string,
+): Promise<{ id: number }> =>
+  odataPost<{ id: number }>(auth, 'image', {
+    is_a_build_of__service: serviceId,
+    is_stored_at__image_location: location,
+    content_hash: contentHash,
+    status: 'success',
+    start_timestamp: new Date().toISOString(),
+  });
+
+/** Create the supervisor release row (version-field tolerant). */
+export const createRelease = async (auth: InstanceAuth, input: CreateReleaseInput): Promise<{ id: number }> => {
+  const versionField = await releaseVersionField(auth);
+  const body: Record<string, unknown> = {
+    belongs_to__application: input.appId,
+    commit: input.commit,
+    composition: input.composition,
+    status: 'success',
+    source: 'cloud',
+    variant: '',
+    [versionField]: input.rawVersion,
+    semver_major: input.semver.major,
+    semver_minor: input.semver.minor,
+    semver_patch: input.semver.patch,
+    semver_prerelease: input.semver.prerelease,
+    semver_build: input.semver.build,
+  };
+
+  if (await releaseSupportsField(auth, 'is_final')) {
+    body.is_final = true;
+  }
+
+  return odataPost<{ id: number }>(auth, 'release', body);
+};
+
+/** Link an image into a release. */
+export const createReleaseImage = async (auth: InstanceAuth, releaseId: number, imageId: number): Promise<void> => {
+  await odataPost<{ id: number }>(auth, 'release_image', { release: releaseId, image: imageId });
+};
+
+// ---------------------------------------------------------------------------
+// Device supervisor target
+// ---------------------------------------------------------------------------
+
+export interface DeviceSupervisorState {
+  current: string | null;
+  targetReleaseId: number | null;
+  targetRawVersion: string | null;
+  targetSemver: string | null;
+}
+
+/** Read a device's supervisor state incl. its managed-by release target. */
+export const getDeviceSupervisorState = async (
+  auth: InstanceAuth,
+  deviceId: number,
+): Promise<DeviceSupervisorState> => {
+  const versionField = await releaseVersionField(auth);
+
+  interface TargetRow {
+    id?: number;
+    raw_version?: string;
+    release_version?: string;
+    semver?: string;
+  }
+
+  interface Row {
+    supervisor_version?: string | null;
+    should_be_managed_by__release?: TargetRow[] | TargetRow | null;
+  }
+
+  const rows = await odataGet<Row>(
+    auth,
+    `/v6/device(${deviceId})?$select=supervisor_version,should_be_managed_by__release` +
+      `&$expand=should_be_managed_by__release($select=id,${versionField},semver)`,
+  );
+
+  const row = rows[0];
+  if (!row) {
+    throw new NotFoundError(`Unknown device: ${deviceId}`);
+  }
+
+  const target = asArray(row.should_be_managed_by__release)[0] ?? null;
+  const targetRawVersion =
+    (target ? (versionField === 'raw_version' ? target.raw_version : target.release_version) : null) ?? null;
+  const targetSemver = target?.semver ?? targetRawVersion;
+
+  return {
+    current: row.supervisor_version ?? null,
+    targetReleaseId: target?.id ?? null,
+    targetRawVersion,
+    targetSemver: targetSemver ?? null,
+  };
+};
+/** PATCH a device's `should be managed by-release` (pine canonical name). */
+export const patchDeviceSupervisorRelease = async (
+  auth: InstanceAuth,
+  deviceId: number,
+  releaseId: number,
+): Promise<void> => {
+  const res = await odataPatch(auth, `/v6/device(${deviceId})`, {
+    should_be_managed_by__release: releaseId,
+  });
+
+  if (!res.ok) {
+    throw new InstanceApiError(await extractErrorMessage(res, `Device update failed (${res.status})`), 400);
+  }
+};

--- a/server/controller/supervisorRelease/registryMirror.ts
+++ b/server/controller/supervisorRelease/registryMirror.ts
@@ -75,6 +75,16 @@ export interface ManifestInspection {
   blobDigests: string[];
 }
 
+/** Digest shape accepted in registry paths — every digest used in a URL is checked. */
+export const isRegistryDigest = (digest: string): boolean => /^sha256:[a-f0-9]{64}$/.test(digest);
+
+const assertDigest = (digest: string): string => {
+  if (!isRegistryDigest(digest)) {
+    throw new RegistryMirrorError(`Invalid registry digest: ${digest}`);
+  }
+  return digest;
+};
+
 /** Inspect a parsed manifest/index: list membership, child manifests, blobs. Pure — unit tested. */
 export const inspectManifest = (manifest: unknown): ManifestInspection => {
   if (!manifest || typeof manifest !== 'object') {
@@ -91,7 +101,11 @@ export const inspectManifest = (manifest: unknown): ManifestInspection => {
       if (!entry || typeof entry !== 'object' || typeof (entry as { digest?: unknown }).digest !== 'string') {
         throw new RegistryMirrorError(`Manifest list entry ${index} has no digest`);
       }
-      return (entry as { digest: string }).digest;
+      const digest = (entry as { digest: string }).digest;
+      if (!isRegistryDigest(digest)) {
+        throw new RegistryMirrorError(`Manifest list entry ${index} has an invalid digest: ${digest}`);
+      }
+      return digest;
     });
     return { isList: true, childManifestDigests: children, blobDigests: [] };
   }
@@ -99,13 +113,13 @@ export const inspectManifest = (manifest: unknown): ManifestInspection => {
   const blobs: string[] = [];
   const config = record.config;
   if (config && typeof config === 'object' && typeof (config as { digest?: unknown }).digest === 'string') {
-    blobs.push((config as { digest: string }).digest);
+    blobs.push(assertDigest((config as { digest: string }).digest));
   }
   const layers = record.layers;
   if (Array.isArray(layers)) {
     for (const layer of layers) {
       if (layer && typeof layer === 'object' && typeof (layer as { digest?: unknown }).digest === 'string') {
-        blobs.push((layer as { digest: string }).digest);
+        blobs.push(assertDigest((layer as { digest: string }).digest));
       }
     }
   }
@@ -126,14 +140,43 @@ interface TokenResponse {
   access_token?: string;
 }
 
-const sourceTokens = new Map<string, string>();
+interface CachedToken {
+  token: string;
+  expiresAt: number;
+}
+
+/** JWT `exp` minus a safety skew; opaque tokens fall back to a short TTL. */
+const tokenExpiryMs = (token: string): number => {
+  try {
+    const payload = JSON.parse(Buffer.from(token.split('.')[1] ?? '', 'base64').toString('utf8')) as {
+      exp?: unknown;
+    };
+    if (typeof payload.exp === 'number' && Number.isFinite(payload.exp) && payload.exp > 0) {
+      return payload.exp * 1000 - 60_000;
+    }
+  } catch {
+    // Opaque token — cannot read an expiry.
+  }
+  return Date.now() + 5 * 60_000;
+};
+
+const freshToken = (cache: Map<string, CachedToken>, key: string): string | undefined => {
+  const cached = cache.get(key);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.token;
+  }
+  cache.delete(key);
+  return undefined;
+};
+
+const sourceTokens = new Map<string, CachedToken>();
 
 const getSourceToken = async (repo: string): Promise<string> => {
   if (!process.env.BALENACLOUD_TOKEN) {
     throw new MirroringNotConfiguredError();
   }
 
-  const cached = sourceTokens.get(repo);
+  const cached = freshToken(sourceTokens, repo);
   if (cached) {
     return cached;
   }
@@ -154,14 +197,16 @@ const getSourceToken = async (repo: string): Promise<string> => {
     throw new UpstreamError('balenaCloud registry token response contained no token');
   }
 
-  sourceTokens.set(repo, token);
+  sourceTokens.set(repo, { token, expiresAt: tokenExpiryMs(token) });
   return token;
 };
 
-const targetTokens = new Map<string, string>();
+const targetTokens = new Map<string, CachedToken>();
 
 const getTargetToken = async (repo: string, callerAuthorization: string): Promise<string> => {
-  const cached = targetTokens.get(repo);
+  // Keyed by caller so one user's registry token is never reused for another.
+  const cacheKey = `${callerAuthorization}|${repo}`;
+  const cached = freshToken(targetTokens, cacheKey);
   if (cached) {
     return cached;
   }
@@ -185,7 +230,7 @@ const getTargetToken = async (repo: string, callerAuthorization: string): Promis
     throw new RegistryMirrorError('Instance registry token response contained no token');
   }
 
-  targetTokens.set(repo, token);
+  targetTokens.set(cacheKey, { token, expiresAt: tokenExpiryMs(token) });
   return token;
 };
 
@@ -274,6 +319,7 @@ const copyBlobIfMissing = async (
   sourceToken: string,
   targetToken: string,
 ): Promise<void> => {
+  assertDigest(digest);
   const targetBase = targetRegistryUrl();
 
   const head = await fetch(`${targetBase}/v2/${repo}/blobs/${digest}`, {
@@ -393,6 +439,7 @@ export const verifyManifestAtTarget = async (
   digest: string,
   callerAuthorization: string,
 ): Promise<boolean> => {
+  assertDigest(digest);
   const token = await getTargetToken(repo, callerAuthorization);
   const head = await fetch(`${targetRegistryUrl()}/v2/${repo}/manifests/${digest}`, {
     method: 'HEAD',
@@ -426,6 +473,7 @@ export const mirrorImage = async (
     /** Recursively copy a manifest, deduped by digest: children first for lists, blobs before their manifest. */
     const copiedManifests = new Set<string>();
     const copyManifest = async (manifestDigest: string): Promise<void> => {
+      assertDigest(manifestDigest);
       if (copiedManifests.has(manifestDigest)) {
         return;
       }

--- a/server/controller/supervisorRelease/registryMirror.ts
+++ b/server/controller/supervisorRelease/registryMirror.ts
@@ -1,0 +1,468 @@
+import { MirroringNotConfiguredError, RegistryMirrorError, UpstreamError } from './errors';
+import { balenaCloudApiUrl } from './cloud';
+
+/**
+ * Byte-identical image mirroring from balenaCloud's registry into the
+ * instance's own registry.
+ *
+ * - Manifests are copied as raw bytes, PUT by digest with the source
+ *   Content-Type, so the digest (and therefore the balenaCloud `content_hash`)
+ *   stays valid at the target.
+ * - Manifest lists / OCI indices recurse into their child manifests first.
+ * - Blobs (config + layers) are HEAD-checked at the target and only copied
+ *   when missing, streaming source→target (never buffered in memory).
+ * - Pulls are authorized with the server-level `BALENACLOUD_TOKEN`; pushes use
+ *   the caller's instance JWT through the instance's `/auth/v1/token`.
+ */
+
+export const SOURCE_REGISTRY_HOST = 'registry2.balena-cloud.com';
+const SOURCE_REGISTRY_URL = `https://${SOURCE_REGISTRY_HOST}`;
+
+export const MANIFEST_ACCEPT_HEADER =
+  'application/vnd.docker.distribution.manifest.v2+json, ' +
+  'application/vnd.docker.distribution.manifest.list.v2+json, ' +
+  'application/vnd.oci.image.manifest.v1+json, ' +
+  'application/vnd.oci.image.index.v1+json';
+
+const LIST_MEDIA_TYPES = new Set([
+  'application/vnd.docker.distribution.manifest.list.v2+json',
+  'application/vnd.oci.image.index.v1+json',
+]);
+
+/** Derive the instance registry host from the instance API URL host: leftmost label → `registry2`. Pure — unit tested. */
+export const deriveRegistryHost = (apiUrl: string): string => {
+  let host: string;
+  try {
+    host = new URL(apiUrl).host;
+  } catch {
+    throw new RegistryMirrorError(`Cannot derive registry host from invalid API URL: ${apiUrl}`);
+  }
+
+  const labels = host.split('.');
+  if (labels.length < 2) {
+    throw new RegistryMirrorError(`Cannot derive registry host from API host: ${host}`);
+  }
+
+  labels[0] = 'registry2';
+  return labels.join('.');
+};
+
+/** Base URL of the instance registry (no trailing slash). */
+export const targetRegistryUrl = (): string => {
+  const configured = process.env.OPEN_BALENA_REGISTRY_URL;
+  if (configured) {
+    return (/^https?:\/\//.test(configured) ? configured : `https://${configured}`).replace(/\/+$/, '');
+  }
+  const apiUrl = process.env.REACT_APP_OPEN_BALENA_API_URL;
+  if (!apiUrl) {
+    throw new RegistryMirrorError('Neither OPEN_BALENA_REGISTRY_URL nor REACT_APP_OPEN_BALENA_API_URL is configured');
+  }
+  return `https://${deriveRegistryHost(apiUrl)}`;
+};
+
+/** Host the instance registry token service expects as `service` parameter. */
+export const targetRegistryHost = (): string => new URL(targetRegistryUrl()).host;
+
+// ---------------------------------------------------------------------------
+// Structure inspection (pure, unit tested)
+// ---------------------------------------------------------------------------
+
+export interface ManifestInspection {
+  isList: boolean;
+  /** Digests of child manifests referenced by a manifest list / OCI index. */
+  childManifestDigests: string[];
+  /** Digests of referenced blobs (config + layers) for a single manifest. */
+  blobDigests: string[];
+}
+
+/** Inspect a parsed manifest/index: list membership, child manifests, blobs. Pure — unit tested. */
+export const inspectManifest = (manifest: unknown): ManifestInspection => {
+  if (!manifest || typeof manifest !== 'object') {
+    throw new RegistryMirrorError('Manifest is not a JSON object');
+  }
+
+  const record = manifest as Record<string, unknown>;
+  const mediaType = typeof record.mediaType === 'string' ? record.mediaType : '';
+  const hasManifests = Array.isArray(record.manifests);
+  const isList = LIST_MEDIA_TYPES.has(mediaType) || (hasManifests && !Array.isArray(record.layers));
+
+  if (isList) {
+    const children = (record.manifests as unknown[]).map((entry, index) => {
+      if (!entry || typeof entry !== 'object' || typeof (entry as { digest?: unknown }).digest !== 'string') {
+        throw new RegistryMirrorError(`Manifest list entry ${index} has no digest`);
+      }
+      return (entry as { digest: string }).digest;
+    });
+    return { isList: true, childManifestDigests: children, blobDigests: [] };
+  }
+
+  const blobs: string[] = [];
+  const config = record.config;
+  if (config && typeof config === 'object' && typeof (config as { digest?: unknown }).digest === 'string') {
+    blobs.push((config as { digest: string }).digest);
+  }
+  const layers = record.layers;
+  if (Array.isArray(layers)) {
+    for (const layer of layers) {
+      if (layer && typeof layer === 'object' && typeof (layer as { digest?: unknown }).digest === 'string') {
+        blobs.push((layer as { digest: string }).digest);
+      }
+    }
+  }
+
+  if (blobs.length === 0 && !Array.isArray(layers) && !config) {
+    throw new RegistryMirrorError('Manifest references neither blobs nor child manifests');
+  }
+
+  return { isList: false, childManifestDigests: [], blobDigests: blobs };
+};
+
+// ---------------------------------------------------------------------------
+// Tokens
+// ---------------------------------------------------------------------------
+
+interface TokenResponse {
+  token?: string;
+  access_token?: string;
+}
+
+const sourceTokens = new Map<string, string>();
+
+const getSourceToken = async (repo: string): Promise<string> => {
+  if (!process.env.BALENACLOUD_TOKEN) {
+    throw new MirroringNotConfiguredError();
+  }
+
+  const cached = sourceTokens.get(repo);
+  if (cached) {
+    return cached;
+  }
+
+  const url =
+    `${balenaCloudApiUrl()}/auth/v1/token?service=${encodeURIComponent(SOURCE_REGISTRY_HOST)}` +
+    `&scope=${encodeURIComponent(`repository:${repo}:pull`)}`;
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${process.env.BALENACLOUD_TOKEN}` },
+  });
+  if (!res.ok) {
+    throw new UpstreamError(`balenaCloud registry token request failed (${res.status}) — check BALENACLOUD_TOKEN`);
+  }
+
+  const body = (await res.json()) as TokenResponse;
+  const token = body.token ?? body.access_token;
+  if (!token) {
+    throw new UpstreamError('balenaCloud registry token response contained no token');
+  }
+
+  sourceTokens.set(repo, token);
+  return token;
+};
+
+const targetTokens = new Map<string, string>();
+
+const getTargetToken = async (repo: string, callerAuthorization: string): Promise<string> => {
+  const cached = targetTokens.get(repo);
+  if (cached) {
+    return cached;
+  }
+
+  const apiUrl = process.env.REACT_APP_OPEN_BALENA_API_URL;
+  if (!apiUrl) {
+    throw new RegistryMirrorError('REACT_APP_OPEN_BALENA_API_URL is not configured on the server');
+  }
+
+  const url =
+    `${apiUrl.replace(/\/+$/, '')}/auth/v1/token?service=${encodeURIComponent(targetRegistryHost())}` +
+    `&scope=${encodeURIComponent(`repository:${repo}:pull,push`)}`;
+  const res = await fetch(url, { headers: { Authorization: callerAuthorization } });
+  if (!res.ok) {
+    throw new RegistryMirrorError(`Instance registry token request failed (${res.status})`);
+  }
+
+  const body = (await res.json()) as TokenResponse;
+  const token = body.token ?? body.access_token;
+  if (!token) {
+    throw new RegistryMirrorError('Instance registry token response contained no token');
+  }
+
+  targetTokens.set(repo, token);
+  return token;
+};
+
+/** Test hook: clear cached tokens. */
+export const resetRegistryTokens = (): void => {
+  sourceTokens.clear();
+  targetTokens.clear();
+};
+
+// ---------------------------------------------------------------------------
+// Per-repo in-process lock (concurrent seeds must not double-copy)
+// ---------------------------------------------------------------------------
+
+const repoLocks = new Map<string, Promise<unknown>>();
+
+/** Serialize work per repository within this process (FIFO on the tail promise). */
+export const withRepoLock = async <T>(repo: string, work: () => Promise<T>): Promise<T> => {
+  const tail = (repoLocks.get(repo) ?? Promise.resolve()) as Promise<unknown>;
+  let release: () => void = () => undefined;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  repoLocks.set(
+    repo,
+    tail.then(() => gate),
+  );
+
+  await tail;
+  try {
+    return await work();
+  } finally {
+    release();
+  }
+};
+
+// ---------------------------------------------------------------------------
+// HTTP plumbing
+// ---------------------------------------------------------------------------
+
+const resolveLocation = (baseUrl: string, location: string | null): string => {
+  if (!location) {
+    throw new RegistryMirrorError('Registry returned no Location header');
+  }
+  if (/^https?:\/\//i.test(location)) {
+    return location;
+  }
+  try {
+    return new URL(location, baseUrl).toString();
+  } catch {
+    throw new RegistryMirrorError(`Registry returned an unusable Location header: ${location}`);
+  }
+};
+
+const registryFetch = async (url: string, init: RequestInit, what: string): Promise<Response> => {
+  const res = await fetch(url, init);
+  if (!res.ok) {
+    let detail = '';
+    try {
+      const body = (await res.json()) as { errors?: { message?: string }[] };
+      detail = (body.errors ?? [])
+        .map((error) => error.message ?? '')
+        .join('; ')
+        .slice(0, 200);
+    } catch {
+      // non-JSON error body
+    }
+    throw new RegistryMirrorError(`${what} failed (${res.status})${detail ? `: ${detail}` : ''}`);
+  }
+  return res;
+};
+
+// ---------------------------------------------------------------------------
+// Copy operations
+// ---------------------------------------------------------------------------
+
+interface ManifestCopy {
+  digest: string;
+  mediaType: string;
+  bytes: Buffer;
+}
+
+/** Copy one blob (config or layer) unless it already exists at the target. Streams, never buffers. */
+const copyBlobIfMissing = async (
+  repo: string,
+  digest: string,
+  sourceToken: string,
+  targetToken: string,
+): Promise<void> => {
+  const targetBase = targetRegistryUrl();
+
+  const head = await fetch(`${targetBase}/v2/${repo}/blobs/${digest}`, {
+    method: 'HEAD',
+    headers: { Authorization: `Bearer ${targetToken}` },
+  });
+  if (head.ok) {
+    return;
+  }
+  if (head.status !== 404) {
+    throw new RegistryMirrorError(`Blob existence check for ${digest} failed (${head.status})`);
+  }
+
+  const source = await registryFetch(
+    `${SOURCE_REGISTRY_URL}/v2/${repo}/blobs/${digest}`,
+    { headers: { Authorization: `Bearer ${sourceToken}` } },
+    `Source blob fetch ${digest}`,
+  );
+  if (!source.body) {
+    throw new RegistryMirrorError(`Source blob ${digest} has no body`);
+  }
+
+  // Start the upload session; the Location may be absolute or relative and may
+  // point at a different host/scheme than the registry API base.
+  const postUrl = `${targetBase}/v2/${repo}/blobs/uploads/`;
+  const post = await fetch(postUrl, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${targetToken}` },
+  });
+  if (post.status !== 202) {
+    throw new RegistryMirrorError(`Blob upload initiation for ${digest} failed (${post.status})`);
+  }
+  const location = resolveLocation(postUrl, post.headers.get('location'));
+  const putUrl = location + (location.includes('?') ? '&' : '?') + `digest=${encodeURIComponent(digest)}`;
+
+  const headers: Record<string, string> = {
+    'Authorization': `Bearer ${targetToken}`,
+    'Content-Type': source.headers.get('content-type') ?? 'application/octet-stream',
+  };
+  const contentLength = source.headers.get('content-length');
+  if (contentLength) {
+    headers['Content-Length'] = contentLength;
+  }
+
+  // `duplex: 'half'` streams the body through without buffering; it is absent
+  // from older RequestInit typings, hence the widened type.
+  const putInit: RequestInit & { duplex?: 'half' } = {
+    method: 'PUT',
+    headers,
+    body: source.body,
+    duplex: 'half',
+  };
+  const put = await fetch(putUrl, putInit);
+  if (put.status !== 201 && put.status !== 204) {
+    let detail = '';
+    try {
+      const body = (await put.json()) as { errors?: { message?: string }[] };
+      detail = (body.errors ?? [])
+        .map((error) => error.message ?? '')
+        .join('; ')
+        .slice(0, 200);
+    } catch {
+      // non-JSON error body
+    }
+    throw new RegistryMirrorError(`Blob upload of ${digest} failed (${put.status})${detail ? `: ${detail}` : ''}`);
+  }
+
+  const uploadedDigest = put.headers.get('docker-content-digest');
+  if (uploadedDigest && uploadedDigest !== digest) {
+    throw new RegistryMirrorError(`Blob upload digest mismatch for ${digest}: registry reported ${uploadedDigest}`);
+  }
+};
+
+/** GET a manifest from the source registry (raw bytes + media type). */
+const fetchSourceManifest = async (repo: string, digest: string, sourceToken: string): Promise<ManifestCopy> => {
+  const res = await registryFetch(
+    `${SOURCE_REGISTRY_URL}/v2/${repo}/manifests/${digest}`,
+    { headers: { Accept: MANIFEST_ACCEPT_HEADER, Authorization: `Bearer ${sourceToken}` } },
+    `Source manifest fetch ${digest}`,
+  );
+
+  const mediaType = res.headers.get('content-type')?.split(';')[0]?.trim();
+  if (!mediaType) {
+    throw new RegistryMirrorError(`Source manifest ${digest} has no Content-Type`);
+  }
+
+  const bytes = Buffer.from(await res.arrayBuffer());
+  return { digest, mediaType, bytes };
+};
+
+/** PUT a manifest at the target, byte-identical, verifying the resulting digest. */
+const putTargetManifest = async (repo: string, manifest: ManifestCopy, targetToken: string): Promise<void> => {
+  const res = await registryFetch(
+    `${targetRegistryUrl()}/v2/${repo}/manifests/${manifest.digest}`,
+    {
+      method: 'PUT',
+      headers: {
+        'Authorization': `Bearer ${targetToken}`,
+        'Content-Type': manifest.mediaType,
+      },
+      body: new Uint8Array(manifest.bytes),
+    },
+    `Target manifest push ${manifest.digest}`,
+  );
+
+  const reported = res.headers.get('docker-content-digest');
+  if (reported && reported !== manifest.digest) {
+    throw new RegistryMirrorError(
+      `Manifest push digest mismatch for ${manifest.digest}: registry reported ${reported}`,
+    );
+  }
+};
+
+/** Verify a manifest digest exists at the target registry. */
+export const verifyManifestAtTarget = async (
+  repo: string,
+  digest: string,
+  callerAuthorization: string,
+): Promise<boolean> => {
+  const token = await getTargetToken(repo, callerAuthorization);
+  const head = await fetch(`${targetRegistryUrl()}/v2/${repo}/manifests/${digest}`, {
+    method: 'HEAD',
+    headers: { Accept: MANIFEST_ACCEPT_HEADER, Authorization: `Bearer ${token}` },
+  });
+  return head.ok;
+};
+
+/**
+ * Copy an image from balenaCloud's registry into the instance registry,
+ * starting at the manifest (list) digest. Recurses into list children and
+ * copies every referenced blob; children are pushed before their list.
+ */
+export const mirrorImage = async (
+  callerAuthorization: string,
+  repo: string,
+  digest: string,
+): Promise<{ repo: string; digest: string }> => {
+  if (!process.env.BALENACLOUD_TOKEN) {
+    throw new MirroringNotConfiguredError();
+  }
+
+  if (!/^[a-z0-9][a-z0-9/_-]*$/.test(repo) || !/^sha256:[a-f0-9]{64}$/.test(digest)) {
+    throw new RegistryMirrorError(`Invalid repository or digest: ${repo} / ${digest}`);
+  }
+
+  return withRepoLock(repo, async () => {
+    const sourceToken = await getSourceToken(repo);
+    const targetToken = await getTargetToken(repo, callerAuthorization);
+
+    /** Recursively copy a manifest, deduped by digest: children first for lists, blobs before their manifest. */
+    const copiedManifests = new Set<string>();
+    const copyManifest = async (manifestDigest: string): Promise<void> => {
+      if (copiedManifests.has(manifestDigest)) {
+        return;
+      }
+      copiedManifests.add(manifestDigest);
+
+      // Idempotency: a manifest already present at the target needs no copy.
+      const head = await fetch(`${targetRegistryUrl()}/v2/${repo}/manifests/${manifestDigest}`, {
+        method: 'HEAD',
+        headers: { Accept: MANIFEST_ACCEPT_HEADER, Authorization: `Bearer ${targetToken}` },
+      });
+      if (head.ok) {
+        return;
+      }
+      if (head.status !== 404) {
+        throw new RegistryMirrorError(`Target manifest existence check for ${manifestDigest} failed (${head.status})`);
+      }
+
+      const manifest = await fetchSourceManifest(repo, manifestDigest, sourceToken);
+      const inspection = inspectManifest(JSON.parse(manifest.bytes.toString('utf8')));
+
+      if (inspection.isList) {
+        // Manifest list / OCI index: copy every child manifest first, then the list itself.
+        for (const childDigest of inspection.childManifestDigests) {
+          await copyManifest(childDigest);
+        }
+      } else {
+        for (const blobDigest of inspection.blobDigests) {
+          await copyBlobIfMissing(repo, blobDigest, sourceToken, targetToken);
+        }
+      }
+
+      await putTargetManifest(repo, manifest, targetToken);
+    };
+
+    // For manifest lists: copy each child manifest first, then the list itself.
+    await copyManifest(digest);
+
+    return { repo, digest };
+  });
+};

--- a/server/controller/supervisorRelease/seed.ts
+++ b/server/controller/supervisorRelease/seed.ts
@@ -1,0 +1,289 @@
+import {
+  CatalogVersion,
+  CloudReleaseImage,
+  dedupeAndOrderReleases,
+  fetchCloudReleaseComposition,
+  fetchReleaseImages,
+  fetchSupervisorApplication,
+  fetchSupervisorReleases,
+  supervisorAppSlug,
+} from './cloud';
+import { NotFoundError, UpstreamError } from './errors';
+import {
+  commitForCloudRelease,
+  createImage,
+  createRelease,
+  createReleaseImage,
+  createService,
+  createSupervisorApplication,
+  DeviceTypeInfo,
+  findAppReleases,
+  findApplicationBySlug,
+  findDeviceTypeByArch,
+  findImageByContentHash,
+  findReleaseImages,
+  findServiceByName,
+  getDeviceTypeBySlug,
+  InstanceAuth,
+  parseSemverFields,
+} from './instance';
+import { mirrorImage, targetRegistryHost, verifyManifestAtTarget } from './registryMirror';
+
+/**
+ * Idempotent seeding of a supervisor version into the instance, in a
+ * crash-safe order that never exposes a release referencing un-mirrored
+ * images:
+ *
+ * app → services → image METADATA (instance location) → MIRROR bytes →
+ * (verify manifest at target) → release → release_image links.
+ */
+
+export interface SeedImageResult {
+  repo: string;
+  digest: string;
+}
+
+export interface SeedResult {
+  appId: number;
+  releaseId: number;
+  images: SeedImageResult[];
+}
+
+/** Extract the repository name from a registry image location (`host/v2/<repo>`). */
+export const repoFromLocation = (location: string): string => {
+  const match = /^[^/]+\/v2\/(.+)$/.exec(location);
+  if (!match) {
+    throw new UpstreamError(`Unexpected balenaCloud image location: ${location}`);
+  }
+  return match[1];
+};
+
+export type SeedPlanStep =
+  | 'create-app'
+  | 'create-service'
+  | 'create-image-metadata'
+  | 'mirror-bytes'
+  | 'create-release'
+  | 'create-release-image'
+  | 'complete';
+
+export interface SeedExistingState {
+  appId?: number;
+  releaseId?: number;
+  existingServiceNames: string[];
+  existingImageHashes: string[];
+  existingReleaseImageIds: number[];
+  bytesVerified: boolean;
+}
+
+/**
+ * Pure decision of which seed steps remain, given the existing instance
+ * state and the cloud catalog facts. Unit tested — the imperative seed below
+ * follows exactly this order.
+ */
+export const planSeedSteps = (
+  existing: SeedExistingState,
+  cloud: { serviceNames: string[]; imageHashes: string[]; imageCount: number },
+): SeedPlanStep[] => {
+  const steps: SeedPlanStep[] = [];
+
+  if (!existing.appId) {
+    steps.push('create-app');
+  }
+  if (cloud.serviceNames.some((name) => !existing.existingServiceNames.includes(name))) {
+    steps.push('create-service');
+  }
+  if (cloud.imageHashes.some((hash) => !existing.existingImageHashes.includes(hash))) {
+    steps.push('create-image-metadata');
+  }
+  if (!existing.bytesVerified) {
+    steps.push('mirror-bytes');
+  }
+  if (!existing.releaseId) {
+    steps.push('create-release');
+  }
+  if (!existing.releaseId || existing.existingReleaseImageIds.length < cloud.imageCount) {
+    steps.push('create-release-image');
+  }
+  if (steps.length === 0) {
+    steps.push('complete');
+  }
+
+  return steps;
+};
+
+// Per-(arch, version) in-process lock: concurrent seeds await the first.
+const seedLocks = new Map<string, Promise<unknown>>();
+
+const withSeedLock = async <T>(key: string, work: () => Promise<T>): Promise<T> => {
+  const tail = (seedLocks.get(key) ?? Promise.resolve()) as Promise<unknown>;
+  let release: () => void = () => undefined;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  seedLocks.set(
+    key,
+    tail.then(() => gate),
+  );
+
+  await tail;
+  try {
+    return await work();
+  } finally {
+    release();
+  }
+};
+
+/** Resolve device type + arch and the cloud catalog for a version listing. */
+export const resolveCatalogForDeviceType = async (
+  auth: InstanceAuth,
+  deviceTypeSlug: string,
+): Promise<{ deviceType: DeviceTypeInfo; applicationId: number; versions: CatalogVersion[] }> => {
+  const deviceType = await getDeviceTypeBySlug(auth, deviceTypeSlug);
+
+  const application = await fetchSupervisorApplication(deviceType.arch);
+  if (!application) {
+    throw new NotFoundError(`balenaCloud has no supervisor application for arch ${deviceType.arch}`);
+  }
+
+  const releases = await fetchSupervisorReleases(application.id);
+  return { deviceType, applicationId: application.id, versions: dedupeAndOrderReleases(releases) };
+};
+
+/** Fetch the cloud images of a specific catalog version. */
+export const fetchCloudImagesForVersion = async (
+  versions: CatalogVersion[],
+  version: string,
+): Promise<{ catalog: CatalogVersion; images: CloudReleaseImage[] }> => {
+  const catalog = versions.find((entry) => entry.semver === version);
+  if (!catalog) {
+    throw new NotFoundError(`Unknown supervisor version ${version} for this device type`);
+  }
+
+  const images = await fetchReleaseImages(catalog.cloudReleaseId);
+  if (images.length === 0) {
+    throw new NotFoundError(`Supervisor version ${version} has no images in the balenaCloud catalog`);
+  }
+
+  return { catalog, images };
+};
+
+/**
+ * Seed (or confirm already seeded) a supervisor version for a device type's
+ * arch and return the instance release id.
+ */
+export const seedSupervisorRelease = async (
+  auth: InstanceAuth,
+  deviceTypeSlug: string,
+  version: string,
+): Promise<SeedResult> => {
+  const { deviceType } = await resolveCatalogForDeviceType(auth, deviceTypeSlug);
+  return withSeedLock(`${deviceType.arch}:${version}`, async () => {
+    const { authorization } = auth;
+    const arch = deviceType.arch;
+    const slug = supervisorAppSlug(arch);
+
+    // 1. Application (idempotent by slug)
+    let app = await findApplicationBySlug(auth, slug);
+    if (!app) {
+      const instanceDeviceType = await findDeviceTypeByArch(auth, arch);
+      app = await createSupervisorApplication(auth, arch, instanceDeviceType.id);
+    }
+    const appId = app.id;
+
+    // 2. Cloud catalog for this version
+    const cloudApp = await fetchSupervisorApplication(arch);
+    if (!cloudApp) {
+      throw new NotFoundError(`balenaCloud has no supervisor application for arch ${arch}`);
+    }
+    const versions = dedupeAndOrderReleases(await fetchSupervisorReleases(cloudApp.id));
+    const { catalog, images } = await fetchCloudImagesForVersion(versions, version);
+
+    // 3. Existing release? (idempotency short-circuit — releases are only
+    // created after mirroring, so an existing release means a completed seed)
+    const existingReleases = await findAppReleases(auth, appId);
+    const existingRelease = existingReleases.find(
+      (release) => release.rawVersion === catalog.rawVersion || release.semver === catalog.semver,
+    );
+
+    // 4. Services (create-if-missing, same names as balenaCloud)
+    const serviceIds = new Map<string, number>();
+    for (const serviceName of [...new Set(images.map((image) => image.serviceName))]) {
+      const existingService = await findServiceByName(auth, appId, serviceName);
+      serviceIds.set(serviceName, existingService?.id ?? (await createService(auth, appId, serviceName)).id);
+    }
+
+    // 5. Image metadata (instance-registry location, balenaCloud digest as content hash)
+    const registryHost = targetRegistryHost();
+    const imageIds: number[] = [];
+    const mirroredImages: SeedImageResult[] = [];
+
+    const verifyAll = async (): Promise<boolean> => {
+      const results = await Promise.all(
+        images.map(async (image) =>
+          verifyManifestAtTarget(repoFromLocation(image.location), image.contentHash, authorization),
+        ),
+      );
+      return results.every((ok) => ok);
+    };
+
+    for (const image of images) {
+      const repo = repoFromLocation(image.location);
+      const existingImage = await findImageByContentHash(auth, image.contentHash);
+
+      let imageId = existingImage?.id;
+      if (!existingImage || !existingServiceMatch(existingImage.serviceId, serviceIds)) {
+        const serviceId = serviceIds.get(image.serviceName);
+        if (!serviceId) {
+          throw new NotFoundError(`No service ${image.serviceName} for image ${repo}`);
+        }
+        const location = `${registryHost}/v2/${repo}`;
+        imageId = (await createImage(auth, serviceId, location, image.contentHash)).id;
+      }
+      if (!imageId) {
+        throw new NotFoundError(`Could not resolve an image row for ${repo}`);
+      }
+
+      imageIds.push(imageId);
+      mirroredImages.push({ repo, digest: image.contentHash });
+    }
+
+    // 6. Mirror bytes (skip only when every manifest is already at the target)
+    const alreadyMirrored = await verifyAll();
+    if (!alreadyMirrored) {
+      for (const image of images) {
+        await mirrorImage(authorization, repoFromLocation(image.location), image.contentHash);
+      }
+      if (!(await verifyAll())) {
+        throw new UpstreamError(`Mirroring of supervisor ${version} did not verify at the target registry`);
+      }
+    }
+
+    // 7. Release (composition copied verbatim from balenaCloud)
+    let releaseId = existingRelease?.id;
+    if (!releaseId) {
+      releaseId = (
+        await createRelease(auth, {
+          appId,
+          commit: commitForCloudRelease(catalog.cloudReleaseId, catalog.rawVersion),
+          rawVersion: catalog.rawVersion,
+          semver: parseSemverFields(catalog.semver),
+          composition: await fetchCloudReleaseComposition(catalog.cloudReleaseId),
+        })
+      ).id;
+    }
+
+    // 8. release_image links
+    const linkedImageIds = new Set((await findReleaseImages(auth, releaseId)).map((link) => link.imageId));
+    for (const imageId of imageIds) {
+      if (!linkedImageIds.has(imageId)) {
+        await createReleaseImage(auth, releaseId, imageId);
+      }
+    }
+
+    return { appId, releaseId, images: mirroredImages };
+  });
+};
+
+const existingServiceMatch = (serviceId: number, serviceIds: Map<string, number>): boolean =>
+  [...serviceIds.values()].includes(serviceId);

--- a/server/controller/supervisorRelease/seed.ts
+++ b/server/controller/supervisorRelease/seed.ts
@@ -112,7 +112,8 @@ export const planSeedSteps = (
   return steps;
 };
 
-// Per-(arch, version) in-process lock: concurrent seeds await the first.
+// Per-arch in-process lock: concurrent seeds serialize (first one creates the
+// app row; later ones — any version — reuse it), preventing duplicate-app races.
 const seedLocks = new Map<string, Promise<unknown>>();
 
 const withSeedLock = async <T>(key: string, work: () => Promise<T>): Promise<T> => {
@@ -172,26 +173,26 @@ export const fetchCloudImagesForVersion = async (
  * Seed (or confirm already seeded) a supervisor version for a device type's
  * arch and return the instance release id.
  */
+/** Guard used by the plan executor below: a planned step must have produced the id. */
+const requireSeedId = (id: number | undefined, what: string): number => {
+  if (id === undefined) {
+    throw new UpstreamError(`Seed plan error: ${what} id missing after planned steps`);
+  }
+  return id;
+};
+
 export const seedSupervisorRelease = async (
   auth: InstanceAuth,
   deviceTypeSlug: string,
   version: string,
 ): Promise<SeedResult> => {
   const { deviceType } = await resolveCatalogForDeviceType(auth, deviceTypeSlug);
-  return withSeedLock(`${deviceType.arch}:${version}`, async () => {
+  return withSeedLock(deviceType.arch, async () => {
     const { authorization } = auth;
     const arch = deviceType.arch;
     const slug = supervisorAppSlug(arch);
 
-    // 1. Application (idempotent by slug)
-    let app = await findApplicationBySlug(auth, slug);
-    if (!app) {
-      const instanceDeviceType = await findDeviceTypeByArch(auth, arch);
-      app = await createSupervisorApplication(auth, arch, instanceDeviceType.id);
-    }
-    const appId = app.id;
-
-    // 2. Cloud catalog for this version
+    // Cloud catalog for this version (before touching the instance)
     const cloudApp = await fetchSupervisorApplication(arch);
     if (!cloudApp) {
       throw new NotFoundError(`balenaCloud has no supervisor application for arch ${arch}`);
@@ -199,24 +200,37 @@ export const seedSupervisorRelease = async (
     const versions = dedupeAndOrderReleases(await fetchSupervisorReleases(cloudApp.id));
     const { catalog, images } = await fetchCloudImagesForVersion(versions, version);
 
-    // 3. Existing release? (idempotency short-circuit — releases are only
-    // created after mirroring, so an existing release means a completed seed)
-    const existingReleases = await findAppReleases(auth, appId);
+    // Existing instance state — lookups only; every creation happens per the plan below.
+    let app = await findApplicationBySlug(auth, slug);
+    const existingReleases = app ? await findAppReleases(auth, app.id) : [];
     const existingRelease = existingReleases.find(
       (release) => release.rawVersion === catalog.rawVersion || release.semver === catalog.semver,
     );
 
-    // 4. Services (create-if-missing, same names as balenaCloud)
+    const serviceNames = [...new Set(images.map((image) => image.serviceName))];
     const serviceIds = new Map<string, number>();
-    for (const serviceName of [...new Set(images.map((image) => image.serviceName))]) {
-      const existingService = await findServiceByName(auth, appId, serviceName);
-      serviceIds.set(serviceName, existingService?.id ?? (await createService(auth, appId, serviceName)).id);
+    const existingServiceNames: string[] = [];
+    for (const serviceName of serviceNames) {
+      const existingService = app ? await findServiceByName(auth, app.id, serviceName) : undefined;
+      if (existingService) {
+        serviceIds.set(serviceName, existingService.id);
+        existingServiceNames.push(serviceName);
+      }
     }
 
-    // 5. Image metadata (instance-registry location, balenaCloud digest as content hash)
     const registryHost = targetRegistryHost();
-    const imageIds: number[] = [];
-    const mirroredImages: SeedImageResult[] = [];
+    const imageIdByHash = new Map<string, number>();
+    const existingImageHashes: string[] = [];
+    for (const image of images) {
+      if (imageIdByHash.has(image.contentHash)) {
+        continue;
+      }
+      const existingImage = await findImageByContentHash(auth, image.contentHash);
+      if (existingImage && existingServiceMatch(existingImage.serviceId, serviceIds)) {
+        imageIdByHash.set(image.contentHash, existingImage.id);
+        existingImageHashes.push(image.contentHash);
+      }
+    }
 
     const verifyAll = async (): Promise<boolean> => {
       const results = await Promise.all(
@@ -227,61 +241,102 @@ export const seedSupervisorRelease = async (
       return results.every((ok) => ok);
     };
 
-    for (const image of images) {
-      const repo = repoFromLocation(image.location);
-      const existingImage = await findImageByContentHash(auth, image.contentHash);
+    const existingReleaseImageIds = existingRelease
+      ? (await findReleaseImages(auth, existingRelease.id)).map((link) => link.imageId)
+      : [];
 
-      let imageId = existingImage?.id;
-      if (!existingImage || !existingServiceMatch(existingImage.serviceId, serviceIds)) {
-        const serviceId = serviceIds.get(image.serviceName);
-        if (!serviceId) {
-          throw new NotFoundError(`No service ${image.serviceName} for image ${repo}`);
-        }
-        const location = `${registryHost}/v2/${repo}`;
-        imageId = (await createImage(auth, serviceId, location, image.contentHash)).id;
-      }
-      if (!imageId) {
-        throw new NotFoundError(`Could not resolve an image row for ${repo}`);
-      }
+    // The pure planner (unit tested) decides which steps remain; execution
+    // follows it exactly, in its order — the tested order IS the real order.
+    const plan = planSeedSteps(
+      {
+        appId: app?.id,
+        releaseId: existingRelease?.id,
+        existingServiceNames,
+        existingImageHashes,
+        existingReleaseImageIds,
+        bytesVerified: await verifyAll(),
+      },
+      {
+        serviceNames,
+        imageHashes: images.map((image) => image.contentHash),
+        imageCount: images.length,
+      },
+    );
 
-      imageIds.push(imageId);
-      mirroredImages.push({ repo, digest: image.contentHash });
-    }
-
-    // 6. Mirror bytes (skip only when every manifest is already at the target)
-    const alreadyMirrored = await verifyAll();
-    if (!alreadyMirrored) {
-      for (const image of images) {
-        await mirrorImage(authorization, repoFromLocation(image.location), image.contentHash);
-      }
-      if (!(await verifyAll())) {
-        throw new UpstreamError(`Mirroring of supervisor ${version} did not verify at the target registry`);
-      }
-    }
-
-    // 7. Release (composition copied verbatim from balenaCloud)
+    let appId = app?.id;
     let releaseId = existingRelease?.id;
-    if (!releaseId) {
-      releaseId = (
-        await createRelease(auth, {
-          appId,
-          commit: commitForCloudRelease(catalog.cloudReleaseId, catalog.rawVersion),
-          rawVersion: catalog.rawVersion,
-          semver: parseSemverFields(catalog.semver),
-          composition: await fetchCloudReleaseComposition(catalog.cloudReleaseId),
-        })
-      ).id;
-    }
 
-    // 8. release_image links
-    const linkedImageIds = new Set((await findReleaseImages(auth, releaseId)).map((link) => link.imageId));
-    for (const imageId of imageIds) {
-      if (!linkedImageIds.has(imageId)) {
-        await createReleaseImage(auth, releaseId, imageId);
+    for (const step of plan) {
+      switch (step) {
+        case 'create-app': {
+          const instanceDeviceType = await findDeviceTypeByArch(auth, arch);
+          app = await createSupervisorApplication(auth, arch, instanceDeviceType.id);
+          appId = app.id;
+          break;
+        }
+        case 'create-service':
+          for (const serviceName of serviceNames) {
+            if (!serviceIds.has(serviceName)) {
+              serviceIds.set(
+                serviceName,
+                (await createService(auth, requireSeedId(appId, 'application'), serviceName)).id,
+              );
+            }
+          }
+          break;
+        case 'create-image-metadata':
+          for (const image of images) {
+            if (imageIdByHash.has(image.contentHash)) {
+              continue;
+            }
+            const serviceId = serviceIds.get(image.serviceName);
+            if (!serviceId) {
+              throw new NotFoundError(`No service ${image.serviceName} for image ${repoFromLocation(image.location)}`);
+            }
+            const location = `${registryHost}/v2/${repoFromLocation(image.location)}`;
+            imageIdByHash.set(image.contentHash, (await createImage(auth, serviceId, location, image.contentHash)).id);
+          }
+          break;
+        case 'mirror-bytes':
+          for (const image of images) {
+            await mirrorImage(authorization, repoFromLocation(image.location), image.contentHash);
+          }
+          if (!(await verifyAll())) {
+            throw new UpstreamError(`Mirroring of supervisor ${version} did not verify at the target registry`);
+          }
+          break;
+        case 'create-release':
+          releaseId = (
+            await createRelease(auth, {
+              appId: requireSeedId(appId, 'application'),
+              commit: commitForCloudRelease(catalog.cloudReleaseId, catalog.rawVersion),
+              rawVersion: catalog.rawVersion,
+              semver: parseSemverFields(catalog.semver),
+              composition: await fetchCloudReleaseComposition(catalog.cloudReleaseId),
+            })
+          ).id;
+          break;
+        case 'create-release-image': {
+          const release = requireSeedId(releaseId, 'release');
+          const linkedImageIds = new Set((await findReleaseImages(auth, release)).map((link) => link.imageId));
+          for (const image of images) {
+            const imageId = imageIdByHash.get(image.contentHash);
+            if (imageId !== undefined && !linkedImageIds.has(imageId)) {
+              await createReleaseImage(auth, release, imageId);
+            }
+          }
+          break;
+        }
+        case 'complete':
+          break;
       }
     }
 
-    return { appId, releaseId, images: mirroredImages };
+    return {
+      appId: requireSeedId(appId, 'application'),
+      releaseId: requireSeedId(releaseId, 'release'),
+      images: images.map((image) => ({ repo: repoFromLocation(image.location), digest: image.contentHash })),
+    };
   });
 };
 

--- a/server/controller/supervisorRelease/update.ts
+++ b/server/controller/supervisorRelease/update.ts
@@ -1,0 +1,58 @@
+import { InstanceApiError } from './errors';
+import { InstanceAuth, patchDeviceSupervisorRelease } from './instance';
+import { SeedResult, seedSupervisorRelease } from './seed';
+
+/**
+ * Ensure a supervisor version is seeded (seeds on first use) and set it as the
+ * target supervisor release of each device with the caller's JWT. The
+ * instance's pine hooks enforce the no-downgrade rule per device; failures are
+ * collected per device so bulk updates tolerate partial failure.
+ */
+
+export interface DeviceUpdateResult {
+  id: number;
+  ok: boolean;
+  message?: string;
+}
+
+export interface BulkUpdateSummary {
+  total: number;
+  updated: number;
+  rejected: number;
+}
+
+/** Aggregate per-device results into a summary. Pure — unit tested. */
+export const aggregateResults = (results: DeviceUpdateResult[]): BulkUpdateSummary => {
+  const updated = results.filter((result) => result.ok).length;
+  return { total: results.length, updated, rejected: results.length - updated };
+};
+
+export interface SupervisorUpdateOutcome {
+  seed: SeedResult;
+  results: DeviceUpdateResult[];
+}
+
+export const updateSupervisorReleases = async (
+  auth: InstanceAuth,
+  deviceTypeSlug: string,
+  version: string,
+  deviceIds: number[],
+): Promise<SupervisorUpdateOutcome> => {
+  // Ensures seeded (idempotent): seeds if the version is not on the instance yet.
+  const seed = await seedSupervisorRelease(auth, deviceTypeSlug, version);
+
+  const results: DeviceUpdateResult[] = [];
+  for (const deviceId of deviceIds) {
+    try {
+      await patchDeviceSupervisorRelease(auth, deviceId, seed.releaseId);
+      results.push({ id: deviceId, ok: true });
+    } catch (error) {
+      // e.g. the API's "Attempt to downgrade supervisor, which is not allowed"
+      const message =
+        error instanceof InstanceApiError || error instanceof Error ? error.message : 'Supervisor update rejected';
+      results.push({ id: deviceId, ok: false, message });
+    }
+  }
+
+  return { seed, results };
+};

--- a/server/index.ts
+++ b/server/index.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { existsSync, readFileSync } from 'node:fs';
 import serialize from 'serialize-javascript';
 import registryImageRoutes from './routes/registryImage';
+import supervisorReleaseRoutes from './routes/supervisorRelease';
 
 dotenv.config();
 
@@ -23,6 +24,7 @@ const CLIENT_ENV_KEYS = [
 const app = express();
 
 app.use('/', registryImageRoutes);
+app.use('/supervisor-releases', supervisorReleaseRoutes);
 app.use(express.static(CLIENT_DIR, { index: false }));
 app.get(/.*/, (_req, res) => {
   const indexPath = path.join(process.cwd(), CLIENT_DIR, 'index.html');

--- a/server/routes/supervisorRelease.ts
+++ b/server/routes/supervisorRelease.ts
@@ -1,0 +1,238 @@
+import { json, Request, Response, Router } from 'express';
+import authorize from '../middleware/authorize';
+import dosProtect from '../middleware/dosProtect';
+import { CatalogVersion, supervisorAppSlug } from '../controller/supervisorRelease/cloud';
+import {
+  InstanceApiError,
+  MirroringNotConfiguredError,
+  NotFoundError,
+  UpstreamError,
+} from '../controller/supervisorRelease/errors';
+import {
+  DeviceSupervisorState,
+  findAppReleases,
+  findApplicationBySlug,
+  getDeviceSupervisorState,
+  InstanceAuth,
+} from '../controller/supervisorRelease/instance';
+import { resolveCatalogForDeviceType, seedSupervisorRelease } from '../controller/supervisorRelease/seed';
+import { DeviceUpdateResult, updateSupervisorReleases } from '../controller/supervisorRelease/update';
+
+interface ErrorResponse {
+  success: false;
+  message: string;
+}
+
+interface SupervisorVersionEntry {
+  version: string;
+  rawVersion: string;
+  seeded: boolean;
+  releaseId?: number;
+}
+
+interface VersionsSuccessResponse {
+  success: true;
+  deviceType: string;
+  arch: string;
+  versions: SupervisorVersionEntry[];
+  mirroringEnabled: boolean;
+}
+
+interface StatusSuccessResponse {
+  success: true;
+  current: string | null;
+  targetReleaseId: number | null;
+  targetVersion: string | null;
+  pending: boolean;
+}
+
+interface SeedSuccessResponse {
+  success: true;
+  appId: number;
+  releaseId: number;
+  images: { repo: string; digest: string }[];
+}
+
+interface UpdateSuccessResponse {
+  success: true;
+  results: DeviceUpdateResult[];
+}
+
+interface SeedRequestBody {
+  deviceType?: string;
+  version?: string;
+}
+
+interface UpdateRequestBody extends SeedRequestBody {
+  deviceIds?: number[];
+}
+
+const router = Router();
+
+router.use(json());
+
+const callerAuth = (req: Request): InstanceAuth => ({ authorization: req.headers.authorization ?? '' });
+
+const sendError = (res: Response, error: unknown): void => {
+  if (error instanceof MirroringNotConfiguredError) {
+    res.status(503).json({ success: false, message: error.message });
+    return;
+  }
+  if (error instanceof UpstreamError) {
+    res.status(502).json({ success: false, message: error.message });
+    return;
+  }
+  if (error instanceof InstanceApiError) {
+    res.status(error.status >= 400 && error.status < 500 ? error.status : 502).json({
+      success: false,
+      message: error.message,
+    });
+    return;
+  }
+  if (error instanceof NotFoundError) {
+    res.status(404).json({ success: false, message: error.message });
+    return;
+  }
+  const message = error instanceof Error ? error.message : 'Supervisor release operation failed';
+  res.status(400).json({ success: false, message });
+};
+
+const wrap = (handler: (req: Request, res: Response) => Promise<void>) => {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      await handler(req, res);
+    } catch (error) {
+      sendError(res, error);
+    }
+  };
+};
+
+/**
+ * GET /supervisor-releases/versions?deviceType=<slug>
+ * Supervisor versions for the device type's arch, newest first, annotated with
+ * whether each is already seeded into the instance.
+ */
+router.get<Record<string, never>, VersionsSuccessResponse | ErrorResponse>(
+  '/versions',
+  ...dosProtect,
+  authorize,
+  wrap(async (req, res) => {
+    const deviceType = String(req.query.deviceType ?? '');
+    if (!deviceType) {
+      res.status(406).json({ success: false, message: 'Request is lacking deviceType in query context' });
+      return;
+    }
+
+    const auth = callerAuth(req);
+    const { deviceType: typeInfo, versions } = await resolveCatalogForDeviceType(auth, deviceType);
+
+    // Merge with instance state: an existing supervisor app release marks the version seeded.
+    const app = await findApplicationBySlug(auth, supervisorAppSlug(typeInfo.arch));
+    const instanceReleases = app ? await findAppReleases(auth, app.id) : [];
+
+    const seededByRaw = new Map(instanceReleases.map((release) => [release.rawVersion, release.id]));
+    const seededBySemver = new Map(instanceReleases.map((release) => [release.semver ?? '', release.id]));
+
+    const entries: SupervisorVersionEntry[] = versions.map((entry: CatalogVersion) => {
+      const releaseId = seededByRaw.get(entry.rawVersion) ?? seededBySemver.get(entry.semver);
+      return {
+        version: entry.semver,
+        rawVersion: entry.rawVersion,
+        seeded: releaseId !== undefined,
+        ...(releaseId !== undefined ? { releaseId } : {}),
+      };
+    });
+
+    res.status(200).json({
+      success: true,
+      deviceType: typeInfo.slug,
+      arch: typeInfo.arch,
+      versions: entries,
+      mirroringEnabled: Boolean(process.env.BALENACLOUD_TOKEN),
+    });
+  }),
+);
+
+/**
+ * GET /supervisor-releases/status?deviceId=<id>
+ * Current and target (pending) supervisor release of a device.
+ */
+router.get<Record<string, never>, StatusSuccessResponse | ErrorResponse>(
+  '/status',
+  ...dosProtect,
+  authorize,
+  wrap(async (req, res) => {
+    const deviceId = Number(req.query.deviceId);
+    if (!Number.isInteger(deviceId) || deviceId <= 0) {
+      res.status(406).json({ success: false, message: 'Request is lacking a valid deviceId in query context' });
+      return;
+    }
+
+    const state: DeviceSupervisorState = await getDeviceSupervisorState(callerAuth(req), deviceId);
+
+    res.status(200).json({
+      success: true,
+      current: state.current,
+      targetReleaseId: state.targetReleaseId,
+      targetVersion: state.targetSemver,
+      pending: Boolean(state.targetReleaseId) && state.current !== null && state.targetSemver !== state.current,
+    });
+  }),
+);
+
+/**
+ * POST /supervisor-releases/seed { deviceType, version }
+ * Idempotently seed a supervisor version into the instance.
+ */
+router.post<Record<string, never>, SeedSuccessResponse | ErrorResponse, SeedRequestBody>(
+  '/seed',
+  ...dosProtect,
+  authorize,
+  wrap(async (req, res) => {
+    const { deviceType, version } = req.body ?? {};
+    if (!deviceType || !version) {
+      res.status(406).json({ success: false, message: 'Request is lacking deviceType/version in body context' });
+      return;
+    }
+
+    const result = await seedSupervisorRelease(callerAuth(req), String(deviceType), String(version));
+    res.status(200).json({ success: true, ...result });
+  }),
+);
+
+/**
+ * POST /supervisor-releases/update { deviceType, version, deviceIds: number[] }
+ * Ensure seeded, then set the target supervisor release per device; reports
+ * per-device results (bulk tolerates partial failure).
+ */
+router.post<Record<string, never>, UpdateSuccessResponse | ErrorResponse, UpdateRequestBody>(
+  '/update',
+  ...dosProtect,
+  authorize,
+  wrap(async (req, res) => {
+    const { deviceType, version, deviceIds } = req.body ?? {};
+    if (!deviceType || !version || !Array.isArray(deviceIds) || deviceIds.length === 0) {
+      res.status(406).json({
+        success: false,
+        message: 'Request is lacking deviceType/version/deviceIds in body context',
+      });
+      return;
+    }
+
+    if (!deviceIds.every((id) => Number.isInteger(id) && (id as number) > 0)) {
+      res.status(406).json({ success: false, message: 'deviceIds must be positive integers' });
+      return;
+    }
+
+    const outcome = await updateSupervisorReleases(
+      callerAuth(req),
+      String(deviceType),
+      String(version),
+      deviceIds as number[],
+    );
+
+    res.status(200).json({ success: true, results: outcome.results });
+  }),
+);
+
+export default router;

--- a/server/routes/supervisorRelease.ts
+++ b/server/routes/supervisorRelease.ts
@@ -6,6 +6,7 @@ import {
   InstanceApiError,
   MirroringNotConfiguredError,
   NotFoundError,
+  RegistryMirrorError,
   UpstreamError,
 } from '../controller/supervisorRelease/errors';
 import {
@@ -87,6 +88,10 @@ const sendError = (res: Response, error: unknown): void => {
       success: false,
       message: error.message,
     });
+    return;
+  }
+  if (error instanceof RegistryMirrorError) {
+    res.status(502).json({ success: false, message: error.message });
     return;
   }
   if (error instanceof NotFoundError) {

--- a/src/components/device.tsx
+++ b/src/components/device.tsx
@@ -50,6 +50,7 @@ import { resolveDeviceTargetRelease } from '../lib/targetRelease';
 import TargetReleaseIcon from '../ui/TargetReleaseIcon';
 import TargetReleaseTooltip from '../ui/TargetReleaseTooltip';
 import DeviceStructuredFilter from '../ui/DeviceStructuredFilter';
+import { SupervisorBulkUpdateButton } from '../ui/SupervisorUpdateButton';
 
 // Get the proper field name for isPinnedOnRelease based on API version
 const isPinnedOnRelease = versions.resource('isPinnedOnRelease', environment.REACT_APP_OPEN_BALENA_API_VERSION);
@@ -88,20 +89,19 @@ export const ReleaseField: React.FC<Omit<FunctionFieldProps<any>, 'render'>> = (
   return (
     <FunctionField
       {...props}
-      render={(record, source) => <ReleaseFieldContent record={record} source={source} theme={theme} />}
+      render={(record, source) =>
+        record && source ? <ReleaseFieldContent record={record} source={source} theme={theme} /> : null
+      }
     />
   );
 };
 
+// Rendered only with non-null record/source (guarded in ReleaseField), so hooks run unconditionally.
 const ReleaseFieldContent: React.FC<{
-  record: Record<string, any> | null;
-  source?: string;
+  record: Record<string, any>;
+  source: string;
   theme: Theme;
 }> = ({ record, source, theme }) => {
-  if (!record || !source) {
-    return null;
-  }
-
   const applicationId = record['belongs to-application'];
   const shouldFetchFleet = Boolean(applicationId);
   const {
@@ -186,6 +186,7 @@ const CustomBulkActionButtons: React.FC<DeleteDeviceButtonProps> = (props) => {
 
   return (
     <React.Fragment>
+      <SupervisorBulkUpdateButton selectedIds={selectedIds} />
       <DeleteDeviceButton size='small' selectedIds={selectedIds} {...props}>
         Delete Selected Devices
       </DeleteDeviceButton>
@@ -227,7 +228,7 @@ const DeviceListActions = () => (
           },
         },
         // Hide original text - the text is directly in the button
-        fontSize: 0,
+        'fontSize': 0,
         '&::after': {
           content: '"Save Filters"',
           fontSize: '0.8125rem',

--- a/src/components/fleet.tsx
+++ b/src/components/fleet.tsx
@@ -21,6 +21,7 @@ import {
   minLength,
   required,
   useUnique,
+  useRecordContext,
   RecordContextProvider,
   CreateProps,
   ToolbarProps,
@@ -38,6 +39,7 @@ import environment from '../lib/reactAppEnv';
 import { resolveFleetTargetRelease } from '../lib/targetRelease';
 import TargetReleaseIcon from '../ui/TargetReleaseIcon';
 import TargetReleaseTooltip from '../ui/TargetReleaseTooltip';
+import { SupervisorFleetUpdateButton } from '../ui/SupervisorUpdateButton';
 
 const isPinnedOnRelease = versions.resource('isPinnedOnRelease', environment.REACT_APP_OPEN_BALENA_API_VERSION);
 
@@ -223,14 +225,21 @@ export const FleetCreate: React.FC<CreateProps> = (props) => {
   );
 };
 
-const CustomToolbar: React.FC<ToolbarProps> = (props) => (
-  <Toolbar {...props} style={{ justifyContent: 'space-between' }}>
-    <SaveButton sx={{ flex: 1 }} />
-    <DeleteFleetButton size='large' sx={{ marginLeft: '40px' }}>
-      Delete
-    </DeleteFleetButton>
-  </Toolbar>
-);
+const CustomToolbar: React.FC<ToolbarProps> = (props) => {
+  const record = useRecordContext<{ id: number }>();
+
+  return (
+    <Toolbar {...props} style={{ justifyContent: 'space-between' }}>
+      <SaveButton sx={{ flex: 1 }} />
+      {record?.id != null && (
+        <SupervisorFleetUpdateButton size='large' sx={{ marginLeft: '40px' }} fleetId={record.id} />
+      )}
+      <DeleteFleetButton size='large' sx={{ marginLeft: '20px' }}>
+        Delete
+      </DeleteFleetButton>
+    </Toolbar>
+  );
+};
 
 export const FleetEdit: React.FC = () => {
   const { id: fleetId } = useParams();

--- a/src/dashboards/device/summaryWidget.tsx
+++ b/src/dashboards/device/summaryWidget.tsx
@@ -95,6 +95,7 @@ const SupervisorVersionCell: React.FC = () => {
     'is of-device type'?: number;
   }>();
   const [status, setStatus] = React.useState<SupervisorStatusResponse | null>(null);
+  const [refreshKey, setRefreshKey] = React.useState(0);
 
   React.useEffect(() => {
     if (!record?.id) {
@@ -113,7 +114,7 @@ const SupervisorVersionCell: React.FC = () => {
     return () => {
       cancelled = true;
     };
-  }, [record?.id]);
+  }, [record?.id, refreshKey]);
 
   if (!record) {
     return null;
@@ -133,6 +134,7 @@ const SupervisorVersionCell: React.FC = () => {
         currentVersion={record['supervisor version'] ?? null}
         size='small'
         sx={{ marginTop: 0.5 }}
+        onUpdated={() => setRefreshKey((key) => key + 1)}
       />
     </Box>
   );

--- a/src/dashboards/device/summaryWidget.tsx
+++ b/src/dashboards/device/summaryWidget.tsx
@@ -19,6 +19,8 @@ import TargetReleaseIcon from '../../ui/TargetReleaseIcon';
 import versions from '../../versions';
 import environment from '../../lib/reactAppEnv';
 import TargetReleaseTooltip from '../../ui/TargetReleaseTooltip';
+import SupervisorUpdateButton from '../../ui/SupervisorUpdateButton';
+import { fetchSupervisorStatus, SupervisorStatusResponse } from '../../lib/supervisorRelease';
 
 const isPinnedOnRelease = versions.resource('isPinnedOnRelease', environment.REACT_APP_OPEN_BALENA_API_VERSION);
 
@@ -29,6 +31,10 @@ const TargetRelease: React.FC = () => {
     return null;
   }
 
+  return <TargetReleaseContent record={record} />;
+};
+
+const TargetReleaseContent: React.FC<{ record: Record<string, any> }> = ({ record }) => {
   const applicationId = record['belongs to-application'];
   const needsFleetFallback = !record['should be running-release'] && Boolean(applicationId);
 
@@ -78,6 +84,57 @@ const TargetRelease: React.FC = () => {
         </TargetReleaseTooltip>
       </ReferenceField>
     </RecordContextProvider>
+  );
+};
+
+/** Supervisor version cell: current version, pending target, and the update action. */
+const SupervisorVersionCell: React.FC = () => {
+  const record = useRecordContext<{
+    'id': number;
+    'supervisor version'?: string | null;
+    'is of-device type'?: number;
+  }>();
+  const [status, setStatus] = React.useState<SupervisorStatusResponse | null>(null);
+
+  React.useEffect(() => {
+    if (!record?.id) {
+      return;
+    }
+    let cancelled = false;
+    fetchSupervisorStatus(record.id)
+      .then((data) => {
+        if (!cancelled) {
+          setStatus(data);
+        }
+      })
+      .catch(() => {
+        // Status display is best-effort; the update dialog surfaces errors.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [record?.id]);
+
+  if (!record) {
+    return null;
+  }
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, alignItems: 'flex-start' }}>
+      <span>{record['supervisor version'] ?? '—'}</span>
+      {status?.pending && status?.targetVersion && (
+        <Tooltip title={`Target supervisor release ${status.targetReleaseId} (raw: ${status.targetVersion})`} arrow>
+          <Chip size='small' color='warning' variant='outlined' label={`target: ${status.targetVersion} (pending)`} />
+        </Tooltip>
+      )}
+      <SupervisorUpdateButton
+        deviceIds={[record.id]}
+        deviceTypeId={record['is of-device type']}
+        currentVersion={record['supervisor version'] ?? null}
+        size='small'
+        sx={{ marginTop: 0.5 }}
+      />
+    </Box>
   );
 };
 
@@ -161,7 +218,7 @@ const SummaryWidget: React.FC = () => {
             <tr>
               <td>
                 <Label>Supervisor Version</Label>
-                <TextField source='supervisor version' />
+                <SupervisorVersionCell />
               </td>
 
               <td>

--- a/src/lib/supervisorRelease.ts
+++ b/src/lib/supervisorRelease.ts
@@ -1,0 +1,134 @@
+/**
+ * Typed client for the UI server's `/supervisor-releases` routes.
+ * Same-origin requests, authorized with the JWT the authProvider/dataProvider
+ * already use (`localStorage.getItem('auth')`).
+ */
+
+import * as balenaSemver from 'balena-semver';
+
+export interface SupervisorVersionEntry {
+  version: string;
+  rawVersion: string;
+  seeded: boolean;
+  releaseId?: number;
+}
+
+export interface SupervisorVersionsResponse {
+  deviceType: string;
+  arch: string;
+  versions: SupervisorVersionEntry[];
+  mirroringEnabled: boolean;
+}
+
+export interface SupervisorStatusResponse {
+  current: string | null;
+  targetReleaseId: number | null;
+  targetVersion: string | null;
+  pending: boolean;
+}
+
+export interface SupervisorDeviceUpdateResult {
+  id: number;
+  ok: boolean;
+  message?: string;
+}
+
+export interface SupervisorUpdateResponse {
+  results: SupervisorDeviceUpdateResult[];
+}
+
+export interface SupervisorSeedResponse {
+  appId: number;
+  releaseId: number;
+  images: { repo: string; digest: string }[];
+}
+
+const authHeaders = (): Record<string, string> => ({
+  Authorization: `Bearer ${localStorage.getItem('auth') ?? ''}`,
+});
+
+class SupervisorReleaseError extends Error {
+  public readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = 'SupervisorReleaseError';
+    this.status = status;
+  }
+}
+
+const request = async <T>(path: string, init?: RequestInit): Promise<T> => {
+  const response = await fetch(`/supervisor-releases${path}`, {
+    ...init,
+    headers: {
+      ...(init?.body ? { 'Content-Type': 'application/json' } : {}),
+      ...authHeaders(),
+      ...(init?.headers as Record<string, string> | undefined),
+    },
+  });
+
+  const body = (await response.json().catch(() => null)) as (Record<string, unknown> & { message?: string }) | null;
+
+  if (!response.ok || !body || body.success === false) {
+    const message =
+      body && typeof body.message === 'string'
+        ? body.message
+        : `Supervisor release request failed (${response.status})`;
+    throw new SupervisorReleaseError(message, response.status);
+  }
+
+  return body as T;
+};
+
+export const fetchSupervisorVersions = (deviceTypeSlug: string): Promise<SupervisorVersionsResponse> =>
+  request<SupervisorVersionsResponse>(`/versions?deviceType=${encodeURIComponent(deviceTypeSlug)}`);
+
+export const fetchSupervisorStatus = (deviceId: number): Promise<SupervisorStatusResponse> =>
+  request<SupervisorStatusResponse>(`/status?deviceId=${deviceId}`);
+
+export const seedSupervisorVersion = (deviceTypeSlug: string, version: string): Promise<SupervisorSeedResponse> =>
+  request<SupervisorSeedResponse>('/seed', {
+    method: 'POST',
+    body: JSON.stringify({ deviceType: deviceTypeSlug, version }),
+  });
+
+export const updateSupervisorVersions = (
+  deviceTypeSlug: string,
+  version: string,
+  deviceIds: number[],
+): Promise<SupervisorUpdateResponse> =>
+  request<SupervisorUpdateResponse>('/update', {
+    method: 'POST',
+    body: JSON.stringify({ deviceType: deviceTypeSlug, version, deviceIds }),
+  });
+
+/**
+ * True when `candidate` is older than `current` in supervisor semver terms —
+ * such versions are listed but disabled ("downgrade not allowed"); the API
+ * would reject them anyway. Pure — unit tested.
+ */
+export const isDowngrade = (candidate: string, current: string | null | undefined): boolean => {
+  if (!current) {
+    return false;
+  }
+  try {
+    return balenaSemver.compare(candidate, current) < 0;
+  } catch {
+    return false;
+  }
+};
+
+/** True when both version strings denote the same supervisor semver (ignoring raw/revision suffixes). Pure — unit tested. */
+export const isSameSupervisorVersion = (left: string, right: string | null | undefined): boolean => {
+  if (!right) {
+    return false;
+  }
+  // balena-semver treats `-<number>` suffixes as revisions, so `19.0.9` and `19.0.9-1786…`
+  // compare unequal; compare the plain `major.minor.patch` part instead.
+  const plain = (value: string): string => value.split('-')[0].split('+')[0];
+  try {
+    return balenaSemver.compare(plain(left), plain(right)) === 0;
+  } catch {
+    return plain(left) === plain(right);
+  }
+};

--- a/src/ui/ActiveFilterChips.tsx
+++ b/src/ui/ActiveFilterChips.tsx
@@ -17,10 +17,7 @@ interface ResolvedLabels {
   releaseLabels: string[];
 }
 
-export const ActiveFilterChips: React.FC<ActiveFilterChipsProps> = ({
-  filters,
-  onRemoveFilter,
-}) => {
+export const ActiveFilterChips: React.FC<ActiveFilterChipsProps> = ({ filters, onRemoveFilter }) => {
   const dataProvider = useDataProvider<DataProvider>();
   const [labels, setLabels] = useState<ResolvedLabels>({
     deviceTypeName: null,
@@ -28,8 +25,7 @@ export const ActiveFilterChips: React.FC<ActiveFilterChipsProps> = ({
     releaseLabels: [],
   });
 
-  const getNonNullReleaseIds = (ids: Array<number | null>): number[] =>
-    ids.filter((id): id is number => id !== null);
+  const getNonNullReleaseIds = (ids: Array<number | null>): number[] => ids.filter((id): id is number => id !== null);
 
   // Resolve IDs to human-readable names
   useEffect(() => {
@@ -224,4 +220,3 @@ export const ActiveFilterChips: React.FC<ActiveFilterChipsProps> = ({
 };
 
 export default ActiveFilterChips;
-

--- a/src/ui/ActorFilter.tsx
+++ b/src/ui/ActorFilter.tsx
@@ -83,4 +83,3 @@ const ActorFilter: React.FC<ActorFilterProps> = ({
 };
 
 export default ActorFilter;
-

--- a/src/ui/DeviceFilterModal.tsx
+++ b/src/ui/DeviceFilterModal.tsx
@@ -50,13 +50,13 @@ interface DeviceType {
 }
 
 interface Fleet {
-  id: number;
+  'id': number;
   'app name': string;
   'is for-device type': number;
 }
 
 interface Release {
-  id: number;
+  'id': number;
   'belongs to-application': number;
   'semver major': number;
   'semver minor': number;
@@ -64,7 +64,7 @@ interface Release {
   'semver prerelease': string;
   'semver build': string;
   'semver revision': number;
-  commit: string;
+  'commit': string;
   'created at': string;
 }
 
@@ -75,17 +75,11 @@ export interface DeviceFilterModalProps {
   currentFilters: DeviceFilterState;
 }
 
-export const DeviceFilterModal: React.FC<DeviceFilterModalProps> = ({
-  open,
-  onClose,
-  onApply,
-  currentFilters,
-}) => {
+export const DeviceFilterModal: React.FC<DeviceFilterModalProps> = ({ open, onClose, onApply, currentFilters }) => {
   // Local state for the modal form
   const [localFilters, setLocalFilters] = useState<DeviceFilterState>(currentFilters);
 
-  const getNonNullReleaseIds = (ids: Array<number | null>): number[] =>
-    ids.filter((id): id is number => id !== null);
+  const getNonNullReleaseIds = (ids: Array<number | null>): number[] => ids.filter((id): id is number => id !== null);
 
   // Fetch device types using useGetList (cached by react-query)
   const { data: deviceTypesData, isLoading: deviceTypesLoading } = useGetList(
@@ -95,7 +89,7 @@ export const DeviceFilterModal: React.FC<DeviceFilterModalProps> = ({
       sort: { field: 'slug', order: 'ASC' },
       filter: {},
     },
-    { enabled: open }
+    { enabled: open },
   );
 
   const deviceTypes = useMemo<DeviceType[]>(
@@ -104,7 +98,7 @@ export const DeviceFilterModal: React.FC<DeviceFilterModalProps> = ({
         id: Number(dt.id),
         slug: dt.slug as string,
       })) ?? [],
-    [deviceTypesData]
+    [deviceTypesData],
   );
 
   // Search state for OS version typeahead
@@ -130,7 +124,7 @@ export const DeviceFilterModal: React.FC<DeviceFilterModalProps> = ({
       sort: { field: 'os version', order: 'ASC' },
       filter: shouldSearchOsVersions ? { 'os version@ilike': debouncedOsVersionSearch } : {},
     },
-    { enabled: open && shouldSearchOsVersions }
+    { enabled: open && shouldSearchOsVersions },
   );
 
   const osVersionOptions = useMemo<string[]>(() => {
@@ -161,17 +155,17 @@ export const DeviceFilterModal: React.FC<DeviceFilterModalProps> = ({
       sort: { field: 'app name', order: 'ASC' },
       filter: fleetsFilter,
     },
-    { enabled: open }
+    { enabled: open },
   );
 
   const fleets = useMemo<Fleet[]>(
     () =>
       fleetsData?.map((fleet) => ({
-        id: Number(fleet.id),
+        'id': Number(fleet.id),
         'app name': fleet['app name'] as string,
         'is for-device type': fleet['is for-device type'] as number,
       })) ?? [],
-    [fleetsData]
+    [fleetsData],
   );
 
   // Build releases filter based on device type and fleet selection
@@ -208,7 +202,7 @@ export const DeviceFilterModal: React.FC<DeviceFilterModalProps> = ({
       sort: { field: 'id', order: 'DESC' },
       filter: releasesFilter,
     },
-    { enabled: open }
+    { enabled: open },
   );
 
   // Track filter changes to reset pagination
@@ -291,12 +285,7 @@ export const DeviceFilterModal: React.FC<DeviceFilterModalProps> = ({
         releaseIds: releases.map((r) => r.id),
       }));
     }
-  }, [
-    open,
-    releases,
-    localFilters.releaseIds,
-    currentFilters.releaseIds,
-  ]);
+  }, [open, releases, localFilters.releaseIds, currentFilters.releaseIds]);
 
   // Filter releases based on device type and fleet selection
   const filteredReleases = useMemo(() => {
@@ -326,19 +315,13 @@ export const DeviceFilterModal: React.FC<DeviceFilterModalProps> = ({
     }
   }, [open, filteredReleases, localFilters.releaseIds]);
 
-  const releaseMatchesSelection = (
-    release: Release,
-    nextDeviceTypeId: number | null,
-    nextFleetId: number | null
-  ) => {
+  const releaseMatchesSelection = (release: Release, nextDeviceTypeId: number | null, nextFleetId: number | null) => {
     if (nextFleetId) {
       return release['belongs to-application'] === nextFleetId;
     }
 
     if (nextDeviceTypeId) {
-      const relevantFleetIds = fleets
-        .filter((f) => f['is for-device type'] === nextDeviceTypeId)
-        .map((f) => f.id);
+      const relevantFleetIds = fleets.filter((f) => f['is for-device type'] === nextDeviceTypeId).map((f) => f.id);
       if (relevantFleetIds.length > 0) {
         return relevantFleetIds.includes(release['belongs to-application']);
       }
@@ -449,10 +432,7 @@ export const DeviceFilterModal: React.FC<DeviceFilterModalProps> = ({
     };
 
     // If all releases are selected, don't apply release filter (empty array = no filter)
-    if (
-      filteredReleases.length > 0 &&
-      filteredReleases.every((r) => effectiveReleaseIds.includes(r.id))
-    ) {
+    if (filteredReleases.length > 0 && filteredReleases.every((r) => effectiveReleaseIds.includes(r.id))) {
       filtersToApply.releaseIds = [];
     }
     onApply(filtersToApply);
@@ -473,9 +453,7 @@ export const DeviceFilterModal: React.FC<DeviceFilterModalProps> = ({
     return currentIds.includes(releaseId);
   };
 
-  const allReleasesSelected =
-    filteredReleases.length > 0 &&
-    filteredReleases.every((r) => isReleaseSelected(r.id));
+  const allReleasesSelected = filteredReleases.length > 0 && filteredReleases.every((r) => isReleaseSelected(r.id));
 
   const noReleasesSelected = localFilters.releaseIds.includes(null);
 
@@ -495,11 +473,7 @@ export const DeviceFilterModal: React.FC<DeviceFilterModalProps> = ({
               <InputLabel shrink sx={{ position: 'relative', transform: 'none', mb: 0.5 }}>
                 Online Status
               </InputLabel>
-              <RadioGroup
-                row
-                value={localFilters.onlineStatus}
-                onChange={handleOnlineStatusChange}
-              >
+              <RadioGroup row value={localFilters.onlineStatus} onChange={handleOnlineStatusChange}>
                 <FormControlLabel value='all' control={<Radio size='small' />} label='All' />
                 <FormControlLabel value='online' control={<Radio size='small' />} label='Online' />
                 <FormControlLabel value='offline' control={<Radio size='small' />} label='Offline' />
@@ -553,23 +527,33 @@ export const DeviceFilterModal: React.FC<DeviceFilterModalProps> = ({
                   Running Release
                 </InputLabel>
                 <Box sx={{ display: 'flex', gap: 1 }}>
-                  <Button size='small' variant='outlined' onClick={handleSelectAllReleases} disabled={allReleasesSelected}>
+                  <Button
+                    size='small'
+                    variant='outlined'
+                    onClick={handleSelectAllReleases}
+                    disabled={allReleasesSelected}
+                  >
                     Select All
                   </Button>
-                  <Button size='small' variant='outlined' onClick={handleSelectNoneReleases} disabled={noReleasesSelected}>
+                  <Button
+                    size='small'
+                    variant='outlined'
+                    onClick={handleSelectNoneReleases}
+                    disabled={noReleasesSelected}
+                  >
                     Select None
                   </Button>
                 </Box>
               </Box>
               <Box
                 sx={(theme) => ({
-                  height: 200,
-                  overflowY: 'scroll',
-                  border: '1px solid',
-                  borderColor: theme.palette.text.disabled,
-                  borderRadius: `${theme.shape.borderRadius}px`,
-                  mt: 1,
-                  p: 1,
+                  'height': 200,
+                  'overflowY': 'scroll',
+                  'border': '1px solid',
+                  'borderColor': theme.palette.text.disabled,
+                  'borderRadius': `${theme.shape.borderRadius}px`,
+                  'mt': 1,
+                  'p': 1,
                   '&:hover': {
                     borderColor: theme.palette.text.primary,
                   },
@@ -594,7 +578,11 @@ export const DeviceFilterModal: React.FC<DeviceFilterModalProps> = ({
                         label={
                           <ListItemText
                             primary={getSemver(release)}
-                            secondary={release['created at'] ? 'Released on ' + new Date(release['created at']).toLocaleDateString() : ''}
+                            secondary={
+                              release['created at']
+                                ? 'Released on ' + new Date(release['created at']).toLocaleDateString()
+                                : ''
+                            }
                           />
                         }
                         sx={{ display: 'flex', width: '100%', m: 0 }}
@@ -630,9 +618,7 @@ export const DeviceFilterModal: React.FC<DeviceFilterModalProps> = ({
               inputValue={osVersionSearch}
               loading={devicesLoading}
               noOptionsText={
-                osVersionSearch.length < 3
-                  ? 'Type at least 3 characters to search'
-                  : 'No OS versions found'
+                osVersionSearch.length < 3 ? 'Type at least 3 characters to search' : 'No OS versions found'
               }
               renderInput={(params) => (
                 <TextField
@@ -673,4 +659,3 @@ export const DeviceFilterModal: React.FC<DeviceFilterModalProps> = ({
 };
 
 export default DeviceFilterModal;
-

--- a/src/ui/DeviceStructuredFilter.tsx
+++ b/src/ui/DeviceStructuredFilter.tsx
@@ -33,8 +33,7 @@ const toOptionalNumber = (value: unknown): number | null => {
   return Number.isNaN(n) ? null : n;
 };
 
-const getNonNullReleaseIds = (ids: Array<number | null>): number[] =>
-  ids.filter((id): id is number => id !== null);
+const getNonNullReleaseIds = (ids: Array<number | null>): number[] => ids.filter((id): id is number => id !== null);
 
 // Helper to convert DeviceFilterState to react-admin filter object
 export const convertToListFilters = (filters: DeviceFilterState): Record<string, unknown> => {
@@ -89,19 +88,14 @@ export const deriveStructuredFilters = (filterValues: Record<string, unknown>): 
 
   if (typeof releaseFilter === 'string') {
     const trimmed = releaseFilter.trim();
-    const inner =
-      trimmed.startsWith('(') && trimmed.endsWith(')')
-        ? trimmed.slice(1, -1)
-        : trimmed;
+    const inner = trimmed.startsWith('(') && trimmed.endsWith(')') ? trimmed.slice(1, -1) : trimmed;
 
     releaseIds = inner
       .split(',')
       .map((id) => Number(id.trim()))
       .filter((id) => !Number.isNaN(id));
   } else if (Array.isArray(releaseFilter)) {
-    releaseIds = releaseFilter
-      .map((id) => Number(id))
-      .filter((id) => !Number.isNaN(id));
+    releaseIds = releaseFilter.map((id) => Number(id)).filter((id) => !Number.isNaN(id));
   }
 
   const osVersion = (filterValues['os version@ilike'] as string) || '';
@@ -154,7 +148,7 @@ const DeviceStructuredFilter: React.FC<DeviceStructuredFilterProps> = ({
 
       setFilters(nextFilters, undefined, false);
     },
-    [filterValues, setFilters]
+    [filterValues, setFilters],
   );
 
   const handleRemoveFilter = React.useCallback(
@@ -182,7 +176,7 @@ const DeviceStructuredFilter: React.FC<DeviceStructuredFilterProps> = ({
 
       handleApplyFilters(updatedFilters);
     },
-    [structuredFilters, handleApplyFilters]
+    [structuredFilters, handleApplyFilters],
   );
 
   const hasActiveFilters = hasActiveStructuredFilters(structuredFilters);
@@ -202,4 +196,3 @@ const DeviceStructuredFilter: React.FC<DeviceStructuredFilterProps> = ({
 };
 
 export default DeviceStructuredFilter;
-

--- a/src/ui/EmbeddedFrame.tsx
+++ b/src/ui/EmbeddedFrame.tsx
@@ -16,30 +16,33 @@ export const EmbeddedFrame: React.FC<EmbeddedFrameProps> = ({
   src,
   srcDoc,
   backgroundColor,
-  minHeight = '400px'
+  minHeight = '400px',
 }) => (
-  <Box sx={{
-    flex: '1',
-    display: 'flex',
-    flexDirection: 'column',
-    minHeight,
-    backgroundColor
-  }}>
-    {(src || srcDoc) && <iframe
-      id={id}
-      title={title}
-      src={src}
-      srcDoc={srcDoc}
-      height="100%"
-      width="100%"
-      style={{
-        flex: '1',
-        position: 'relative',
-        border: 'none'
-      }}
-    />}
+  <Box
+    sx={{
+      flex: '1',
+      display: 'flex',
+      flexDirection: 'column',
+      minHeight,
+      backgroundColor,
+    }}
+  >
+    {(src || srcDoc) && (
+      <iframe
+        id={id}
+        title={title}
+        src={src}
+        srcDoc={srcDoc}
+        height='100%'
+        width='100%'
+        style={{
+          flex: '1',
+          position: 'relative',
+          border: 'none',
+        }}
+      />
+    )}
   </Box>
 );
 
 export default EmbeddedFrame;
-

--- a/src/ui/SupervisorUpdateButton.tsx
+++ b/src/ui/SupervisorUpdateButton.tsx
@@ -1,0 +1,336 @@
+import React from 'react';
+import { Button, ButtonProps, Tooltip } from '@mui/material';
+import SystemUpdateAltIcon from '@mui/icons-material/SystemUpdateAlt';
+import { Identifier, useDataProvider, useNotify } from 'react-admin';
+import type { DataProvider } from 'react-admin';
+import SupervisorUpdateDialog from './SupervisorUpdateDialog';
+import { isDowngrade } from '../lib/supervisorRelease';
+
+/**
+ * Buttons that open the SupervisorUpdateDialog:
+ *
+ * - `SupervisorUpdateButton` — one device (or pre-resolved ids sharing a type)
+ * - `SupervisorBulkUpdateButton` — react-admin bulk selection (must share one device type)
+ * - `SupervisorFleetUpdateButton` — every device of a fleet, grouped by device type
+ */
+
+interface DeviceTypeGroup {
+  deviceTypeId: number;
+  deviceIds: number[];
+  currentVersion: string | null;
+}
+
+/** Group device records by their device type and pick the lowest reported supervisor version per group. */
+export const groupDevicesByDeviceType = (
+  devices: { 'id': number | string; 'is of-device type'?: number; 'supervisor version'?: string | null }[],
+): DeviceTypeGroup[] => {
+  const groups = new Map<number, DeviceTypeGroup & { versions: string[] }>();
+  for (const device of devices) {
+    const deviceTypeId = device['is of-device type'];
+    if (typeof deviceTypeId !== 'number') {
+      continue;
+    }
+    const group = groups.get(deviceTypeId) ?? { deviceTypeId, deviceIds: [], currentVersion: null, versions: [] };
+    group.deviceIds.push(Number(device.id));
+    if (device['supervisor version']) {
+      group.versions.push(device['supervisor version']);
+    }
+    groups.set(deviceTypeId, group);
+  }
+
+  return [...groups.values()].map(({ versions, ...group }) => ({
+    ...group,
+    // Most conservative current version: anything below the fleet minimum is a downgrade for at least one device.
+    currentVersion: versions.reduce<string | null>(
+      (lowest, version) => (lowest === null || isDowngrade(version, lowest) ? version : lowest),
+      null,
+    ),
+  }));
+};
+
+const resolveDeviceTypeSlug = async (dataProvider: DataProvider, deviceTypeId: number): Promise<string | null> => {
+  const { data } = await dataProvider.getOne<{ id: number; slug: string }>('device type', { id: deviceTypeId });
+  return data?.slug ?? null;
+};
+
+export interface SupervisorUpdateButtonProps {
+  deviceIds: number[];
+  deviceTypeSlug?: string;
+  deviceTypeId?: number;
+  currentVersion?: string | null;
+  title?: string;
+  label?: string;
+  variant?: ButtonProps['variant'];
+  size?: ButtonProps['size'];
+  sx?: ButtonProps['sx'];
+  style?: React.CSSProperties;
+  disabled?: boolean;
+}
+
+export const SupervisorUpdateButton: React.FC<SupervisorUpdateButtonProps> = ({
+  deviceIds,
+  deviceTypeSlug,
+  deviceTypeId,
+  currentVersion,
+  title,
+  label = 'Update Supervisor',
+  variant = 'outlined',
+  size,
+  sx,
+  style,
+  disabled,
+}) => {
+  const dataProvider = useDataProvider<DataProvider>();
+  const notify = useNotify();
+  const [open, setOpen] = React.useState(false);
+  const [slug, setSlug] = React.useState<string | null>(deviceTypeSlug ?? null);
+  const [busy, setBusy] = React.useState(false);
+
+  const openDialog = async (): Promise<void> => {
+    let targetSlug = deviceTypeSlug ?? null;
+    if (!targetSlug && deviceTypeId !== undefined) {
+      setBusy(true);
+      try {
+        targetSlug = await resolveDeviceTypeSlug(dataProvider, deviceTypeId);
+      } catch {
+        targetSlug = null;
+      } finally {
+        setBusy(false);
+      }
+    }
+
+    if (!targetSlug) {
+      notify('Unable to resolve the device type for the supervisor update', { type: 'error' });
+      return;
+    }
+
+    setSlug(targetSlug);
+    setOpen(true);
+  };
+
+  if (deviceIds.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <Tooltip title='Update the supervisor version targeted for these devices'>
+        <span>
+          <Button
+            variant={variant}
+            size={size}
+            sx={sx}
+            style={style}
+            onClick={openDialog}
+            disabled={disabled || busy}
+            startIcon={<SystemUpdateAltIcon />}
+          >
+            {label}
+          </Button>
+        </span>
+      </Tooltip>
+      {slug && (
+        <SupervisorUpdateDialog
+          open={open}
+          onClose={() => setOpen(false)}
+          deviceTypeSlug={slug}
+          currentVersion={currentVersion}
+          deviceIds={deviceIds}
+          title={title}
+        />
+      )}
+    </>
+  );
+};
+
+export interface SupervisorBulkUpdateButtonProps {
+  selectedIds: Identifier[];
+  variant?: ButtonProps['variant'];
+  size?: ButtonProps['size'];
+}
+
+export const SupervisorBulkUpdateButton: React.FC<SupervisorBulkUpdateButtonProps> = ({
+  selectedIds,
+  variant = 'outlined',
+  size = 'small',
+}) => {
+  const dataProvider = useDataProvider<DataProvider>();
+  const notify = useNotify();
+  const [busy, setBusy] = React.useState(false);
+  const [target, setTarget] = React.useState<{ slug: string; ids: number[]; currentVersion: string | null } | null>(
+    null,
+  );
+
+  const openDialog = async (): Promise<void> => {
+    setBusy(true);
+    try {
+      const { data: devices } = await dataProvider.getMany<{
+        'id': number;
+        'is of-device type'?: number;
+        'supervisor version'?: string | null;
+      }>('device', { ids: selectedIds.map((id) => Number(id)) });
+
+      const groups = groupDevicesByDeviceType(devices as never[]);
+      if (groups.length !== 1) {
+        notify('Select devices of a single device type to update their supervisor', { type: 'warning' });
+        return;
+      }
+
+      const slug = await resolveDeviceTypeSlug(dataProvider, groups[0].deviceTypeId);
+      if (!slug) {
+        notify('Unable to resolve the device type for the supervisor update', { type: 'error' });
+        return;
+      }
+
+      setTarget({ slug, ids: groups[0].deviceIds, currentVersion: groups[0].currentVersion });
+    } catch (error) {
+      notify(error instanceof Error ? error.message : 'Failed to load selected devices', { type: 'error' });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (selectedIds.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <Tooltip title='Update the supervisor for all selected devices (single device type only)'>
+        <span>
+          <Button
+            variant={variant}
+            size={size}
+            onClick={openDialog}
+            disabled={busy}
+            startIcon={<SystemUpdateAltIcon />}
+          >
+            Update Supervisor
+          </Button>
+        </span>
+      </Tooltip>
+      {target && (
+        <SupervisorUpdateDialog
+          open
+          onClose={() => setTarget(null)}
+          deviceTypeSlug={target.slug}
+          currentVersion={target.currentVersion}
+          deviceIds={target.ids}
+          title='Update Supervisor — Selected Devices'
+        />
+      )}
+    </>
+  );
+};
+
+export interface SupervisorFleetUpdateButtonProps {
+  fleetId: number | string;
+  variant?: ButtonProps['variant'];
+  size?: ButtonProps['size'];
+  sx?: ButtonProps['sx'];
+}
+
+export const SupervisorFleetUpdateButton: React.FC<SupervisorFleetUpdateButtonProps> = ({
+  fleetId,
+  variant = 'outlined',
+  size = 'large',
+}) => {
+  const dataProvider = useDataProvider<DataProvider>();
+  const notify = useNotify();
+  const [busy, setBusy] = React.useState(false);
+  // Dialog queue: fleets normally span one device type; if several, run them one after another.
+  const [queue, setQueue] = React.useState<{ slug: string; ids: number[]; currentVersion: string | null }[]>([]);
+
+  const openDialog = async (): Promise<void> => {
+    setBusy(true);
+    try {
+      const devices: {
+        'id': number;
+        'is of-device type'?: number;
+        'supervisor version'?: string | null;
+      }[] = [];
+
+      let page = 1;
+      for (;;) {
+        const result = await dataProvider.getList<{
+          'id': number;
+          'is of-device type'?: number;
+          'supervisor version'?: string | null;
+        }>('device', {
+          pagination: { page, perPage: 1000 },
+          sort: { field: 'id', order: 'ASC' },
+          filter: { 'belongs to-application': fleetId },
+        });
+        devices.push(...result.data);
+        const total = result.total ?? devices.length;
+        if (devices.length >= total || result.data.length === 0) {
+          break;
+        }
+        page += 1;
+      }
+
+      if (devices.length === 0) {
+        notify('This fleet has no devices', { type: 'info' });
+        return;
+      }
+
+      const groups = groupDevicesByDeviceType(devices as never[]);
+      const entries: { slug: string; ids: number[]; currentVersion: string | null }[] = [];
+      for (const group of groups) {
+        const slug = await resolveDeviceTypeSlug(dataProvider, group.deviceTypeId);
+        if (slug) {
+          entries.push({ slug, ids: group.deviceIds, currentVersion: group.currentVersion });
+        }
+      }
+
+      if (entries.length === 0) {
+        notify('Unable to resolve the device types of this fleet', { type: 'error' });
+        return;
+      }
+
+      setQueue(entries);
+    } catch (error) {
+      notify(error instanceof Error ? error.message : 'Failed to load fleet devices', { type: 'error' });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const current = queue[0] ?? null;
+
+  return (
+    <>
+      <Tooltip
+        title={
+          queue.length > 1
+            ? `Updating fleet devices (${queue.length} device types, one dialog per type)`
+            : 'Update the supervisor for all devices of this fleet'
+        }
+      >
+        <span>
+          <Button
+            variant={variant}
+            size={size}
+            onClick={openDialog}
+            disabled={busy}
+            startIcon={<SystemUpdateAltIcon />}
+          >
+            Update Supervisor
+          </Button>
+        </span>
+      </Tooltip>
+      {current && (
+        <SupervisorUpdateDialog
+          open
+          onClose={() => setQueue((items) => items.slice(1))}
+          deviceTypeSlug={current.slug}
+          currentVersion={current.currentVersion}
+          deviceIds={current.ids}
+          title='Update Supervisor — Fleet Devices'
+        />
+      )}
+    </>
+  );
+};
+
+export default SupervisorUpdateButton;

--- a/src/ui/SupervisorUpdateButton.tsx
+++ b/src/ui/SupervisorUpdateButton.tsx
@@ -53,6 +53,19 @@ const resolveDeviceTypeSlug = async (dataProvider: DataProvider, deviceTypeId: n
   return data?.slug ?? null;
 };
 
+/** Warn when devices had to be skipped because they lack a device type. */
+const notifySkippedDevices = (
+  total: number,
+  groups: DeviceTypeGroup[],
+  notify: (message: string, options: { type: 'info' | 'warning' | 'error' }) => void,
+): void => {
+  const grouped = groups.reduce((count, group) => count + group.deviceIds.length, 0);
+  const skipped = total - grouped;
+  if (skipped > 0) {
+    notify(`${skipped} device(s) skipped — no device type on record`, { type: 'warning' });
+  }
+};
+
 export interface SupervisorUpdateButtonProps {
   deviceIds: number[];
   deviceTypeSlug?: string;
@@ -65,6 +78,8 @@ export interface SupervisorUpdateButtonProps {
   sx?: ButtonProps['sx'];
   style?: React.CSSProperties;
   disabled?: boolean;
+  /** Called after a successful apply, so parents can refresh stale state. */
+  onUpdated?: () => void;
 }
 
 export const SupervisorUpdateButton: React.FC<SupervisorUpdateButtonProps> = ({
@@ -79,6 +94,7 @@ export const SupervisorUpdateButton: React.FC<SupervisorUpdateButtonProps> = ({
   sx,
   style,
   disabled,
+  onUpdated,
 }) => {
   const dataProvider = useDataProvider<DataProvider>();
   const notify = useNotify();
@@ -137,6 +153,7 @@ export const SupervisorUpdateButton: React.FC<SupervisorUpdateButtonProps> = ({
           currentVersion={currentVersion}
           deviceIds={deviceIds}
           title={title}
+          onUpdated={onUpdated}
         />
       )}
     </>
@@ -171,6 +188,7 @@ export const SupervisorBulkUpdateButton: React.FC<SupervisorBulkUpdateButtonProp
       }>('device', { ids: selectedIds.map((id) => Number(id)) });
 
       const groups = groupDevicesByDeviceType(devices as never[]);
+      notifySkippedDevices(devices.length, groups, notify);
       if (groups.length !== 1) {
         notify('Select devices of a single device type to update their supervisor', { type: 'warning' });
         return;
@@ -275,6 +293,7 @@ export const SupervisorFleetUpdateButton: React.FC<SupervisorFleetUpdateButtonPr
       }
 
       const groups = groupDevicesByDeviceType(devices as never[]);
+      notifySkippedDevices(devices.length, groups, notify);
       const entries: { slug: string; ids: number[]; currentVersion: string | null }[] = [];
       for (const group of groups) {
         const slug = await resolveDeviceTypeSlug(dataProvider, group.deviceTypeId);

--- a/src/ui/SupervisorUpdateDialog.tsx
+++ b/src/ui/SupervisorUpdateDialog.tsx
@@ -34,6 +34,8 @@ export interface SupervisorUpdateDialogProps {
   currentVersion?: string | null;
   deviceIds: number[];
   title?: string;
+  /** Called once after a successful apply — lets parents refresh stale state. */
+  onUpdated?: () => void;
 }
 
 type ApplyPhase = 'idle' | 'applying' | 'done';
@@ -53,6 +55,7 @@ const SupervisorUpdateDialog: React.FC<SupervisorUpdateDialogProps> = ({
   currentVersion,
   deviceIds,
   title,
+  onUpdated,
 }) => {
   const [catalog, setCatalog] = React.useState<SupervisorVersionsResponse | null>(null);
   const [isLoading, setIsLoading] = React.useState(false);
@@ -109,6 +112,7 @@ const SupervisorUpdateDialog: React.FC<SupervisorUpdateDialogProps> = ({
       const response = await updateSupervisorVersions(deviceTypeSlug, selected.version, deviceIds);
       setResults(response.results);
       setPhase('done');
+      onUpdated?.();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Supervisor update failed');
       setPhase('idle');

--- a/src/ui/SupervisorUpdateDialog.tsx
+++ b/src/ui/SupervisorUpdateDialog.tsx
@@ -1,0 +1,250 @@
+import React from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  LinearProgress,
+  List,
+  ListItemButton,
+  ListItemText,
+  Typography,
+} from '@mui/material';
+import CheckIcon from '@mui/icons-material/Check';
+import CloseIcon from '@mui/icons-material/Close';
+import {
+  fetchSupervisorVersions,
+  isDowngrade,
+  isSameSupervisorVersion,
+  SupervisorDeviceUpdateResult,
+  SupervisorVersionEntry,
+  SupervisorVersionsResponse,
+  updateSupervisorVersions,
+} from '../lib/supervisorRelease';
+
+export interface SupervisorUpdateDialogProps {
+  open: boolean;
+  onClose: () => void;
+  deviceTypeSlug: string;
+  currentVersion?: string | null;
+  deviceIds: number[];
+  title?: string;
+}
+
+type ApplyPhase = 'idle' | 'applying' | 'done';
+
+const SUPERVISOR_UPDATE_HINT =
+  'This may take a while: the image (~150 MB per version) is copied into your registry on first use, which can take minutes.';
+
+/**
+ * Dialog listing the supervisor versions available for a device type, marking
+ * the current one, disabling downgrades, and applying the selected version to
+ * the given devices (the server seeds the version implicitly when needed).
+ */
+const SupervisorUpdateDialog: React.FC<SupervisorUpdateDialogProps> = ({
+  open,
+  onClose,
+  deviceTypeSlug,
+  currentVersion,
+  deviceIds,
+  title,
+}) => {
+  const [catalog, setCatalog] = React.useState<SupervisorVersionsResponse | null>(null);
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [selected, setSelected] = React.useState<SupervisorVersionEntry | null>(null);
+  const [phase, setPhase] = React.useState<ApplyPhase>('idle');
+  const [results, setResults] = React.useState<SupervisorDeviceUpdateResult[] | null>(null);
+
+  React.useEffect(() => {
+    if (!open || !deviceTypeSlug) {
+      return;
+    }
+
+    const controller = new AbortController();
+    setCatalog(null);
+    setError(null);
+    setSelected(null);
+    setResults(null);
+    setPhase('idle');
+    setIsLoading(true);
+
+    fetchSupervisorVersions(deviceTypeSlug)
+      .then((data) => {
+        if (!controller.signal.aborted) {
+          setCatalog(data);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!controller.signal.aborted) {
+          setError(err instanceof Error ? err.message : 'Failed to load supervisor versions');
+        }
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => controller.abort();
+  }, [open, deviceTypeSlug]);
+
+  const isBulk = deviceIds.length > 1;
+  const mirroringEnabled = catalog?.mirroringEnabled ?? true;
+  const canApply = selected !== null && phase === 'idle' && (mirroringEnabled || selected.seeded);
+
+  const apply = async (): Promise<void> => {
+    if (!selected) {
+      return;
+    }
+
+    setPhase('applying');
+    setError(null);
+    try {
+      const response = await updateSupervisorVersions(deviceTypeSlug, selected.version, deviceIds);
+      setResults(response.results);
+      setPhase('done');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Supervisor update failed');
+      setPhase('idle');
+    }
+  };
+
+  const renderVersionLabel = (entry: SupervisorVersionEntry): React.ReactNode => {
+    const current = isSameSupervisorVersion(entry.version, currentVersion);
+    const downgrade = isDowngrade(entry.version, currentVersion ?? null);
+    return (
+      <Box component='span' sx={{ display: 'inline-flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+        <span>{entry.version}</span>
+        {current && <Chip size='small' color='info' variant='outlined' label='current' />}
+        {entry.seeded && !current && <Chip size='small' variant='outlined' label='seeded' />}
+        {downgrade && <Chip size='small' color='default' variant='outlined' label='downgrade not allowed' />}
+      </Box>
+    );
+  };
+
+  return (
+    <Dialog open={open} onClose={phase === 'applying' ? undefined : onClose} maxWidth='sm' fullWidth>
+      <DialogTitle>{title ?? 'Update Supervisor'}</DialogTitle>
+      <DialogContent>
+        <Typography variant='body2' color='text.secondary' sx={{ mb: 1 }}>
+          Device type <strong>{deviceTypeSlug}</strong>
+          {currentVersion ? (
+            <>
+              {' — current supervisor version '}
+              <strong>{currentVersion}</strong>
+            </>
+          ) : null}
+          {isBulk ? ` — ${deviceIds.length} devices selected` : ''}
+        </Typography>
+
+        {catalog && !catalog.mirroringEnabled && (
+          <Alert severity='warning' sx={{ mt: 1, mb: 1 }}>
+            Supervisor image mirroring is not configured on the server (missing <code>BALENACLOUD_TOKEN</code>). Version
+            listing still works, but updating to a version that is not yet <strong>seeded</strong> will fail. Set{' '}
+            <code>BALENACLOUD_TOKEN</code> on the open-balena-ui server to enable one-click supervisor updates.
+          </Alert>
+        )}
+
+        {error && (
+          <Alert severity='error' sx={{ mt: 1, mb: 1 }}>
+            {error}
+          </Alert>
+        )}
+
+        {isLoading && (
+          <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}>
+            <CircularProgress size={24} />
+          </Box>
+        )}
+
+        {!isLoading && catalog && phase !== 'applying' && (
+          <List
+            dense
+            sx={{ maxHeight: 320, overflow: 'auto', border: '1px solid', borderColor: 'divider', borderRadius: 1 }}
+          >
+            {catalog.versions.length === 0 && (
+              <ListItemButton disabled>
+                <ListItemText primary='No supervisor versions found for this device type' />
+              </ListItemButton>
+            )}
+            {catalog.versions.map((entry) => {
+              const downgrade = isDowngrade(entry.version, currentVersion ?? null);
+              const selectable = !downgrade && (mirroringEnabled || entry.seeded);
+              return (
+                <ListItemButton
+                  key={entry.version}
+                  disabled={!selectable}
+                  selected={selected?.version === entry.version}
+                  onClick={() => setSelected(entry)}
+                >
+                  <ListItemText
+                    primary={renderVersionLabel(entry)}
+                    secondary={
+                      downgrade
+                        ? 'Downgrading the supervisor is not allowed'
+                        : entry.rawVersion !== entry.version
+                          ? `raw: ${entry.rawVersion}`
+                          : undefined
+                    }
+                  />
+                </ListItemButton>
+              );
+            })}
+          </List>
+        )}
+
+        {phase === 'applying' && (
+          <Box sx={{ mt: 2, mb: 1 }}>
+            <LinearProgress />
+            <Typography variant='body2' sx={{ mt: 1 }}>
+              {selected?.seeded
+                ? 'Applying update to devices…'
+                : 'Seeding supervisor version: copying metadata and mirroring image bytes into your registry…'}
+            </Typography>
+            <Typography variant='body2' color='text.secondary' sx={{ mt: 0.5 }}>
+              {SUPERVISOR_UPDATE_HINT}
+            </Typography>
+          </Box>
+        )}
+
+        {phase === 'done' && results && (
+          <Box sx={{ mt: 1 }}>
+            <Typography variant='subtitle2' gutterBottom>
+              {results.every((result) => result.ok)
+                ? `Done — supervisor target set to ${selected?.version} for ${results.length} device(s)`
+                : `Finished with ${results.filter((result) => !result.ok).length} rejection(s):`}
+            </Typography>
+            <List dense>
+              {results.map((result) => (
+                <ListItemButton key={result.id} disabled sx={{ cursor: 'default' }}>
+                  {result.ok ? (
+                    <CheckIcon color='success' fontSize='small' sx={{ mr: 1 }} />
+                  ) : (
+                    <CloseIcon color='error' fontSize='small' sx={{ mr: 1 }} />
+                  )}
+                  <ListItemText primary={`Device ${result.id}`} secondary={result.ok ? undefined : result.message} />
+                </ListItemButton>
+              ))}
+            </List>
+          </Box>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={phase === 'applying'}>
+          {phase === 'done' ? 'Close' : 'Cancel'}
+        </Button>
+        <Button variant='contained' onClick={apply} disabled={!canApply}>
+          {phase === 'applying' ? 'Updating…' : `Update${isBulk ? ` ${deviceIds.length} devices` : ''}`}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default SupervisorUpdateDialog;

--- a/tests/supervisorRelease/mirror.test.ts
+++ b/tests/supervisorRelease/mirror.test.ts
@@ -226,3 +226,43 @@ test('blob uploads follow the upload session Location (relative path, absolute U
     restoreFetch();
   }
 });
+
+test('hostile digests inside manifest JSON are rejected before any registry call', async () => {
+  const { inspectManifest, mirrorImage } = await import('../../server/controller/supervisorRelease/registryMirror');
+  const { RegistryMirrorError } = await import('../../server/controller/supervisorRelease/errors');
+
+  // Manifest list with a traversal digest in a child entry
+  const hostileList = {
+    schemaVersion: 2,
+    mediaType: 'application/vnd.docker.distribution.manifest.list.v2+json',
+    manifests: [{ mediaType: 'application/vnd.docker.distribution.manifest.v2+json', size: 7, digest: '../../evil' }],
+  };
+  assert.throws(() => inspectManifest(hostileList), RegistryMirrorError);
+
+  // Single manifest with a hostile config digest
+  const hostileManifest = {
+    schemaVersion: 2,
+    mediaType: 'application/vnd.docker.distribution.manifest.v2+json',
+    config: { digest: 'sha256:short' },
+    layers: [{ digest: 'http://attacker/x' }],
+  };
+  assert.throws(() => inspectManifest(hostileManifest), RegistryMirrorError);
+
+  // Entry point still rejects traversal digests outright (no fetch performed)
+  process.env.BALENACLOUD_TOKEN = 'token';
+  let fetches = 0;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () => {
+    fetches += 1;
+    return new Response(null, { status: 404 });
+  }) as typeof fetch;
+  try {
+    await assert.rejects(mirrorImage('Bearer caller', 'a/b', '../../evil'), RegistryMirrorError);
+    await assert.rejects(mirrorImage('Bearer caller', 'a/b', 'sha256:xyz'), RegistryMirrorError);
+    assert.equal(fetches, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+    delete process.env.BALENACLOUD_TOKEN;
+    resetRegistryTokens();
+  }
+});

--- a/tests/supervisorRelease/mirror.test.ts
+++ b/tests/supervisorRelease/mirror.test.ts
@@ -1,0 +1,228 @@
+import assert from 'node:assert/strict';
+import { test, beforeEach } from 'node:test';
+import { MirroringNotConfiguredError } from '../../server/controller/supervisorRelease/errors';
+import { mirrorImage, resetRegistryTokens } from '../../server/controller/supervisorRelease/registryMirror';
+
+/**
+ * Full mirror flow against fixture docker manifests, with fetch fully mocked:
+ * no network. Verifies blob existence checks, streamed uploads (POST →
+ * Location → PUT ?digest=), manifest-list recursion (children before the
+ * list), byte-identical manifest PUTs with the source Content-Type, and the
+ * digest verification against the registry's docker-content-digest header.
+ */
+
+const sha = (char: string): string => `sha256:${char.repeat(64)}`;
+const childManifest = {
+  schemaVersion: 2,
+  mediaType: 'application/vnd.docker.distribution.manifest.v2+json',
+  config: { mediaType: 'application/vnd.docker.container.image.v1+json', size: 7, digest: sha('a') },
+  layers: [{ mediaType: 'application/vnd.docker.image.rootfs.diff.tar.gzip', size: 9, digest: sha('b') }],
+};
+const manifestList = {
+  schemaVersion: 2,
+  mediaType: 'application/vnd.docker.distribution.manifest.list.v2+json',
+  manifests: [{ mediaType: childManifest.mediaType, size: 5, digest: sha('c') }],
+};
+
+interface Recorded {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body?: unknown;
+}
+
+const calls: Recorded[] = [];
+/** Digests the fake target registry reports as already present (blobs + manifests). */
+const presentAtTarget = new Set<string>();
+/** Blobs the fake source registry serves. */
+const sourceBlobs = new Map<string, string>([
+  [sha('a'), 'config-bytes'],
+  [sha('b'), 'layer-bytes'],
+]);
+/** Manifests the fake source registry serves, by digest. */
+const sourceManifests = new Map<string, { bytes: string; contentType: string }>([
+  [sha('c'), { bytes: JSON.stringify(childManifest), contentType: childManifest.mediaType }],
+  [sha('d'), { bytes: JSON.stringify(manifestList), contentType: manifestList.mediaType }],
+]);
+
+const jsonResponse = (status: number, body: unknown, headers: Record<string, string> = {}): Response =>
+  new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json', ...headers } });
+
+const installFetchMock = (): void => {
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const url = String(input);
+    const method = (init?.method ?? 'GET').toUpperCase();
+    const headers = Object.fromEntries(new Headers((init?.headers as HeadersInit) ?? {}).entries()) as Record<
+      string,
+      string
+    >;
+    calls.push({ method, url, headers, body: init?.body });
+
+    // --- token endpoints ---
+    if (url.includes('/auth/v1/token')) {
+      const isSource = url.includes('api.balena-cloud.com');
+      if (isSource && !process.env.BALENACLOUD_TOKEN) {
+        return jsonResponse(401, {});
+      }
+      const wantsPush = /pull[,|%2C]+push/.test(decodeURIComponent(url));
+      return jsonResponse(200, { token: wantsPush ? 'target-token' : 'source-token' });
+    }
+
+    // --- source registry (registry2.balena-cloud.com) ---
+    if (url.startsWith('https://registry2.balena-cloud.com/')) {
+      const manifestMatch = /\/manifests\/(sha256:[a-f0-9]+)$/.exec(url);
+      if (manifestMatch) {
+        const manifest = sourceManifests.get(manifestMatch[1]);
+        if (!manifest) {
+          return jsonResponse(404, { errors: [{ message: 'manifest unknown' }] });
+        }
+        return new Response(manifest.bytes, {
+          status: 200,
+          headers: { 'content-type': manifest.contentType },
+        });
+      }
+      const blobMatch = /\/blobs\/(sha256:[a-f0-9]+)$/.exec(url);
+      if (blobMatch) {
+        const blob = sourceBlobs.get(blobMatch[1]);
+        if (!blob) {
+          return jsonResponse(404, { errors: [{ message: 'blob unknown' }] });
+        }
+        return new Response(blob, {
+          status: 200,
+          headers: { 'content-type': 'application/octet-stream', 'content-length': String(blob.length) },
+        });
+      }
+    }
+
+    // --- target registry (instance) ---
+    if (url.includes('/v2/') && url.includes('registry2.balena.example.com')) {
+      if (method === 'HEAD') {
+        const digest = /(?:blobs|manifests)\/(sha256:[a-f0-9]+)$/.exec(url)?.[1];
+        return new Response(null, { status: presentAtTarget.has(digest ?? '') ? 200 : 404 });
+      }
+      if (method === 'POST' && url.endsWith('/blobs/uploads/')) {
+        // Relative Location on a path — exercises the redirect resolution.
+        return new Response(null, {
+          status: 202,
+          headers: { location: '/v2/r1/blobs/uploads/upload-1?_state=abc123' },
+        });
+      }
+      if (method === 'PUT') {
+        if (url.includes('/blobs/uploads/')) {
+          const digest = /digest=(sha256:[a-f0-9]+)/.exec(url)?.[1] ?? '';
+          presentAtTarget.add(digest);
+          return new Response(null, { status: 201, headers: { 'docker-content-digest': digest } });
+        }
+        if (url.includes('/manifests/')) {
+          const digest = /manifests\/(sha256:[a-f0-9]+)$/.exec(url)?.[1] ?? '';
+          presentAtTarget.add(digest);
+          return new Response(null, { status: 201, headers: { 'docker-content-digest': digest } });
+        }
+      }
+    }
+
+    return jsonResponse(500, { errors: [{ message: `unmocked ${method} ${url}` }] });
+  }) as typeof fetch;
+};
+
+const restoreFetch = (): void => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  delete (globalThis as { fetch?: typeof fetch }).fetch;
+};
+
+beforeEach(() => {
+  calls.length = 0;
+  presentAtTarget.clear();
+  resetRegistryTokens();
+  process.env.BALENACLOUD_TOKEN = 'cloud-jwt';
+  process.env.REACT_APP_OPEN_BALENA_API_URL = 'https://api.balena.example.com';
+  delete process.env.OPEN_BALENA_REGISTRY_URL;
+});
+
+test('mirroring without BALENACLOUD_TOKEN raises the typed not-configured error', async () => {
+  delete process.env.BALENACLOUD_TOKEN;
+  await assert.rejects(() => mirrorImage('Bearer caller', 'r1', sha('d')), MirroringNotConfiguredError);
+});
+
+test('mirror copies list children and their blobs before the list, byte-identical', async () => {
+  installFetchMock();
+  try {
+    const result = await mirrorImage('Bearer caller', 'r1', sha('d'));
+
+    assert.deepEqual(result, { repo: 'r1', digest: sha('d') });
+
+    const methods = calls.map((call) => `${call.method} ${call.url.split('example.com').pop() ?? call.url}`);
+    const childManifestPut = methods.findIndex((entry) => entry === `PUT /v2/r1/manifests/${sha('c')}`);
+    const listPut = methods.findIndex((entry) => entry === `PUT /v2/r1/manifests/${sha('d')}`);
+    const blobUploads = methods.filter((entry) => entry.startsWith('PUT /v2/r1/blobs/uploads/'));
+
+    // Children before the list, and both blob uploads happened exactly once.
+    assert.ok(childManifestPut > -1, 'child manifest is pushed');
+    assert.ok(listPut > childManifestPut, 'manifest list is pushed after its child');
+    assert.equal(blobUploads.length, 2, 'config + layer are uploaded');
+
+    // Blobs streamed via the upload session with the digest query parameter.
+    for (const upload of blobUploads) {
+      assert.match(upload, /digest=sha256%3A[0-9a-f]{64}/);
+    }
+
+    // Manifest PUTs are byte-identical: the exact fixture bytes with the source Content-Type.
+    const listPutCall = calls.find((call) => call.method === 'PUT' && call.url.endsWith(`/manifests/${sha('d')}`))!;
+    assert.equal(listPutCall.headers['content-type'], manifestList.mediaType);
+    const putBody =
+      typeof listPutCall.body === 'string'
+        ? listPutCall.body
+        : new TextDecoder().decode(listPutCall.body as Uint8Array);
+    assert.equal(putBody, JSON.stringify(manifestList));
+
+    // Pulls authenticated with the server token, pushes with the caller-derived target token.
+    const sourceManifestGet = calls.find(
+      (call) => call.method === 'GET' && call.url.includes(`registry2.balena-cloud.com/v2/r1/manifests/${sha('c')}`),
+    )!;
+    assert.equal(sourceManifestGet.headers['authorization'], 'Bearer source-token');
+    assert.equal(listPutCall.headers['authorization'], 'Bearer target-token');
+  } finally {
+    restoreFetch();
+  }
+});
+
+test('already-present blobs are skipped and manifests are not re-pushed', async () => {
+  presentAtTarget.add(sha('a'));
+  presentAtTarget.add(sha('b'));
+  presentAtTarget.add(sha('c'));
+  presentAtTarget.add(sha('d'));
+
+  installFetchMock();
+  try {
+    await mirrorImage('Bearer caller', 'r1', sha('d'));
+
+    const targetWrites = calls.filter(
+      (call) => call.url.includes('registry2.balena.example.com') && (call.method === 'PUT' || call.method === 'POST'),
+    );
+    assert.equal(targetWrites.length, 0, 'nothing is written when everything exists');
+  } finally {
+    restoreFetch();
+  }
+});
+
+test('blob uploads follow the upload session Location (relative path, absolute URL)', async () => {
+  installFetchMock();
+  try {
+    await mirrorImage('Bearer caller', 'r1', sha('c'));
+
+    const post = calls.find((call) => call.method === 'POST' && call.url.endsWith('/v2/r1/blobs/uploads/'));
+    const put = calls.find((call) => call.method === 'PUT' && call.url.includes('/blobs/uploads/'));
+
+    assert.ok(post, 'upload session is initiated');
+    assert.ok(put, 'upload is completed');
+    assert.equal(
+      new URL(put!.url).host,
+      'registry2.balena.example.com',
+      'relative Location resolved against the target host',
+    );
+    assert.match(put!.url, /\/v2\/r1\/blobs\/uploads\/upload-1/);
+    assert.match(put!.url, /_state=abc123/);
+  } finally {
+    restoreFetch();
+  }
+});

--- a/tests/supervisorRelease/registry.test.ts
+++ b/tests/supervisorRelease/registry.test.ts
@@ -1,0 +1,143 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { parseSemverFields, commitForCloudRelease } from '../../server/controller/supervisorRelease/instance';
+import {
+  deriveRegistryHost,
+  inspectManifest,
+  withRepoLock,
+} from '../../server/controller/supervisorRelease/registryMirror';
+
+test('semver parsing fills the release semver_* fields', () => {
+  assert.deepEqual(parseSemverFields('19.0.9'), { major: 19, minor: 0, patch: 9, prerelease: '', build: '' });
+  assert.deepEqual(parseSemverFields(' 20.1.3-rev1 '), {
+    major: 20,
+    minor: 1,
+    patch: 3,
+    prerelease: 'rev1',
+    build: '',
+  });
+  assert.deepEqual(parseSemverFields('1.2.3-beta.1+build.5'), {
+    major: 1,
+    minor: 2,
+    patch: 3,
+    prerelease: 'beta.1',
+    build: 'build.5',
+  });
+
+  assert.throws(() => parseSemverFields('not-a-version'));
+});
+
+test('seed commit is deterministic and capped at 40 chars', () => {
+  const first = commitForCloudRelease(4260587, '19.0.9-1786970539365');
+  assert.equal(first, commitForCloudRelease(4260587, '19.0.9-1786970539365'));
+  assert.notEqual(first, commitForCloudRelease(4260588, '19.0.9-1786970539365'));
+  assert.equal(first.length, 40);
+  assert.match(first, /^[a-f0-9]+$/);
+});
+
+test('registry host derivation replaces the leftmost DNS label with registry2', () => {
+  assert.equal(deriveRegistryHost('https://api.balena.example.com'), 'registry2.balena.example.com');
+  assert.equal(deriveRegistryHost('https://api.example.org:8080'), 'registry2.example.org:8080');
+  assert.throws(() => deriveRegistryHost('https://localhost'));
+  assert.throws(() => deriveRegistryHost('not a url'));
+});
+
+const singleManifest = {
+  schemaVersion: 2,
+  mediaType: 'application/vnd.docker.distribution.manifest.v2+json',
+  config: {
+    mediaType: 'application/vnd.docker.container.image.v1+json',
+    size: 2186,
+    digest: 'sha256:' + 'a'.repeat(64),
+  },
+  layers: [
+    {
+      mediaType: 'application/vnd.docker.image.rootfs.diff.tar.gzip',
+      size: 65011753,
+      digest: 'sha256:' + 'b'.repeat(64),
+    },
+    { mediaType: 'application/vnd.docker.image.rootfs.diff.tar.gzip', size: 1220, digest: 'sha256:' + 'c'.repeat(64) },
+  ],
+};
+
+const manifestList = {
+  schemaVersion: 2,
+  mediaType: 'application/vnd.docker.distribution.manifest.list.v2+json',
+  manifests: [
+    {
+      mediaType: 'application/vnd.docker.distribution.manifest.v2+json',
+      size: 1152,
+      digest: 'sha256:' + 'd'.repeat(64),
+      platform: { architecture: 'arm', os: 'linux', variant: 'v8' },
+    },
+    {
+      mediaType: 'application/vnd.docker.distribution.manifest.v2+json',
+      size: 1152,
+      digest: 'sha256:' + 'e'.repeat(64),
+      platform: { architecture: 'amd64', os: 'linux' },
+    },
+  ],
+};
+
+const ociIndex = {
+  schemaVersion: 2,
+  mediaType: 'application/vnd.oci.image.index.v1+json',
+  manifests: [
+    { mediaType: 'application/vnd.oci.image.manifest.v1+json', digest: 'sha256:' + 'f'.repeat(64), size: 999 },
+  ],
+};
+
+test('single manifest inspection yields config + layer blobs, no children', () => {
+  const inspection = inspectManifest(singleManifest);
+
+  assert.equal(inspection.isList, false);
+  assert.deepEqual(inspection.childManifestDigests, []);
+  assert.deepEqual(inspection.blobDigests, [
+    'sha256:' + 'a'.repeat(64),
+    'sha256:' + 'b'.repeat(64),
+    'sha256:' + 'c'.repeat(64),
+  ]);
+});
+
+test('docker manifest list inspection recurses into child manifests only', () => {
+  const inspection = inspectManifest(manifestList);
+
+  assert.equal(inspection.isList, true);
+  assert.deepEqual(inspection.childManifestDigests, ['sha256:' + 'd'.repeat(64), 'sha256:' + 'e'.repeat(64)]);
+  assert.deepEqual(inspection.blobDigests, []);
+});
+
+test('OCI index inspection is treated as a list too', () => {
+  const inspection = inspectManifest(ociIndex);
+
+  assert.equal(inspection.isList, true);
+  assert.deepEqual(inspection.childManifestDigests, ['sha256:' + 'f'.repeat(64)]);
+});
+
+test('manifests without recognized structure are rejected', () => {
+  assert.throws(() => inspectManifest({}));
+  assert.throws(() => inspectManifest('nope'));
+  assert.throws(() => inspectManifest({ manifests: [{ noDigest: true }] }));
+});
+
+test('withRepoLock serializes work per repository', async () => {
+  const order: string[] = [];
+
+  const first = withRepoLock('repo', async () => {
+    order.push('first-start');
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    order.push('first-end');
+  });
+  const second = withRepoLock('repo', async () => {
+    order.push('second-start');
+    await new Promise((resolve) => setTimeout(resolve, 1));
+    order.push('second-end');
+  });
+  const other = withRepoLock('other-repo', async () => {
+    order.push('other-start');
+  });
+
+  await Promise.all([first, second, other]);
+
+  assert.deepEqual(order, ['first-start', 'other-start', 'first-end', 'second-start', 'second-end']);
+});

--- a/tests/supervisorRelease/seed.test.ts
+++ b/tests/supervisorRelease/seed.test.ts
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { planSeedSteps, repoFromLocation } from '../../server/controller/supervisorRelease/seed';
+import { aggregateResults, DeviceUpdateResult } from '../../server/controller/supervisorRelease/update';
+import { isDowngrade, isSameSupervisorVersion } from '../../src/lib/supervisorRelease';
+
+const completeState = {
+  appId: 7,
+  releaseId: 42,
+  existingServiceNames: ['core'],
+  existingImageHashes: ['sha256:' + 'a'.repeat(64)],
+  existingReleaseImageIds: [101],
+  bytesVerified: true,
+};
+
+test('a fully seeded version plans no work', () => {
+  assert.deepEqual(
+    planSeedSteps(completeState, {
+      serviceNames: ['core'],
+      imageHashes: ['sha256:' + 'a'.repeat(64)],
+      imageCount: 1,
+    }),
+    ['complete'],
+  );
+});
+
+test('a cold seed plans every step in crash-safe order', () => {
+  const steps = planSeedSteps(
+    {
+      existingServiceNames: [],
+      existingImageHashes: [],
+      existingReleaseImageIds: [],
+      bytesVerified: false,
+    },
+    { serviceNames: ['core', 'service-relay'], imageHashes: ['sha256:x', 'sha256:y'], imageCount: 2 },
+  );
+
+  assert.deepEqual(steps, [
+    'create-app',
+    'create-service',
+    'create-image-metadata',
+    'mirror-bytes',
+    'create-release',
+    'create-release-image',
+  ]);
+});
+
+test('metadata existing but bytes unverified still mirrors before release', () => {
+  const steps = planSeedSteps(
+    { ...completeState, releaseId: undefined, bytesVerified: false, existingReleaseImageIds: [] },
+    { serviceNames: ['core'], imageHashes: ['sha256:' + 'a'.repeat(64)], imageCount: 1 },
+  );
+
+  assert.deepEqual(steps, ['mirror-bytes', 'create-release', 'create-release-image']);
+});
+
+test('a crashed seed resumes: bytes there, release missing', () => {
+  const steps = planSeedSteps(
+    { ...completeState, releaseId: undefined, existingReleaseImageIds: [] },
+    { serviceNames: ['core'], imageHashes: ['sha256:' + 'a'.repeat(64)], imageCount: 1 },
+  );
+
+  assert.deepEqual(steps, ['create-release', 'create-release-image']);
+});
+
+test('release present but not all images linked finishes the links', () => {
+  const steps = planSeedSteps(
+    {
+      ...completeState,
+      existingServiceNames: ['core', 'service-relay'],
+      existingImageHashes: ['sha256:' + 'a'.repeat(64), 'sha256:' + 'b'.repeat(64)],
+      existingReleaseImageIds: [101],
+    },
+    {
+      serviceNames: ['core', 'service-relay'],
+      imageHashes: ['sha256:' + 'a'.repeat(64), 'sha256:' + 'b'.repeat(64)],
+      imageCount: 2,
+    },
+  );
+
+  assert.deepEqual(steps, ['create-release-image']);
+});
+
+test('missing release_image links are detected by count', () => {
+  const steps = planSeedSteps(
+    { ...completeState, existingReleaseImageIds: [] },
+    { serviceNames: ['core'], imageHashes: ['sha256:' + 'a'.repeat(64)], imageCount: 1 },
+  );
+
+  assert.deepEqual(steps, ['create-release-image']);
+});
+
+test('repo names are extracted from balenaCloud image locations', () => {
+  assert.equal(
+    repoFromLocation('registry2.balena-cloud.com/v2/830e5bb7294e5583620451186e08b5de'),
+    '830e5bb7294e5583620451186e08b5de',
+  );
+  assert.throws(() => repoFromLocation('example.com/some/repo'));
+});
+
+test('bulk aggregation counts updated and rejected devices', () => {
+  const results: DeviceUpdateResult[] = [
+    { id: 1, ok: true },
+    { id: 2, ok: false, message: 'Attempt to downgrade supervisor, which is not allowed' },
+    { id: 3, ok: true },
+  ];
+
+  assert.deepEqual(aggregateResults(results), { total: 3, updated: 2, rejected: 1 });
+  assert.deepEqual(aggregateResults([]), { total: 0, updated: 0, rejected: 0 });
+});
+
+test('downgrade pre-filter marks versions older than the current one', () => {
+  assert.equal(isDowngrade('19.0.8', '19.0.9'), true);
+  assert.equal(isDowngrade('19.0.9', '19.0.9'), false);
+  assert.equal(isDowngrade('19.0.10', '19.0.9'), false);
+  assert.equal(isDowngrade('20.0.0', '19.0.9'), false);
+  assert.equal(isDowngrade('19.0.9', null), false);
+  assert.equal(isDowngrade('19.0.9', undefined), false);
+});
+
+test('raw-version suffixes compare equal to their semver', () => {
+  assert.equal(isDowngrade('19.0.9', '19.0.9-1786970539365'), false);
+  assert.equal(isSameSupervisorVersion('19.0.9', '19.0.9-1786970539365'), true);
+  assert.equal(isSameSupervisorVersion('19.0.9', '19.0.10'), false);
+  assert.equal(isSameSupervisorVersion('19.0.9', null), false);
+});

--- a/tests/supervisorRelease/versions.test.ts
+++ b/tests/supervisorRelease/versions.test.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  CloudRelease,
+  dedupeAndOrderReleases,
+  supervisorAppSlug,
+  isSafeODataToken,
+} from '../../server/controller/supervisorRelease/cloud';
+
+const release = (id: number, raw: string, semver: string, variant = ''): CloudRelease => ({
+  id,
+  raw_version: raw,
+  semver,
+  variant,
+  composition: {},
+});
+
+test('dedupe keeps the newest raw_version per semver', () => {
+  // Ordered as the API returns them: $orderby=id desc
+  const releases = [
+    release(30, '19.0.9-1786970539365', '19.0.9'),
+    release(29, '19.0.9-1786819799993', '19.0.9'),
+    release(28, '19.0.8', '19.0.8'),
+  ];
+
+  const versions = dedupeAndOrderReleases(releases);
+
+  assert.equal(versions.length, 2);
+  assert.equal(versions[0].semver, '19.0.9');
+  assert.equal(versions[0].rawVersion, '19.0.9-1786970539365');
+  assert.equal(versions[0].cloudReleaseId, 30);
+});
+
+test('dedupe drops empty semver/raw_version rows', () => {
+  const releases = [
+    release(30, '19.0.9', '19.0.9'),
+    { id: 31, raw_version: '', semver: '', variant: '', composition: {} },
+    { id: 32, raw_version: 'x', semver: '', variant: '', composition: {} },
+  ];
+
+  assert.equal(dedupeAndOrderReleases(releases).length, 1);
+});
+
+test('versions are ordered semver-descending (balena-semver, prereleases first)', () => {
+  const releases = [
+    release(10, '19.0.2', '19.0.2'),
+    release(9, '19.0.10', '19.0.10'),
+    release(8, '19.0.9', '19.0.9'),
+    release(7, '20.0.0rev1', '20.0.0'),
+  ];
+
+  const ordered = dedupeAndOrderReleases(releases).map((entry) => entry.semver);
+
+  assert.deepEqual(ordered, ['20.0.0', '19.0.10', '19.0.9', '19.0.2']);
+});
+
+test('arch maps to the balenaCloud supervisor app slug', () => {
+  assert.equal(supervisorAppSlug('aarch64'), 'balena_os/aarch64-supervisor');
+  assert.equal(supervisorAppSlug('amd64'), 'balena_os/amd64-supervisor');
+  assert.equal(supervisorAppSlug('armv7hf'), 'balena_os/armv7hf-supervisor');
+});
+
+test('OData filter tokens are restricted to safe characters', () => {
+  assert.equal(isSafeODataToken('aarch64'), true);
+  assert.equal(isSafeODataToken('i386-nlp'), true);
+  assert.equal(isSafeODataToken("aarch64'"), false);
+  assert.equal(isSafeODataToken('aarch64 OR 1=1'), false);
+  assert.equal(isSafeODataToken('%20'), false);
+});

--- a/types/balena-semver.d.ts
+++ b/types/balena-semver.d.ts
@@ -1,0 +1,28 @@
+declare module 'balena-semver' {
+  export interface ParsedSemver {
+    major: number;
+    minor: number;
+    patch: number;
+    prerelease: string[];
+    build: string[];
+    version: string;
+    raw: string;
+    revision?: number | null;
+  }
+
+  export function compare(v: string, w: string): number;
+  export function rcompare(v: string, w: string): number;
+  export function gt(v: string, w: string): boolean;
+  export function gte(v: string, w: string): boolean;
+  export function lt(v: string, w: string): boolean;
+  export function lte(v: string, w: string): boolean;
+  export function eq(v: string, w: string): boolean;
+  export function valid(v: string): boolean;
+  export function parse(v: string): ParsedSemver | null;
+  export function major(v: string): number;
+  export function prerelease(v: string): string[];
+  export function getRevision(v: string): number | null;
+  export function satisfies(v: string, range: string): boolean;
+  export function maxSatisfying<T extends string>(versions: T[], range: string): T | null;
+  export function inc(v: string, release: string): string;
+}


### PR DESCRIPTION
## Summary

Adds **supervisor version management** to the webui: list the supervisor versions available for a device type (from balenaCloud's public catalog), make the instance self-sufficient for them (metadata + container image bytes), and retarget devices — single device or fleet bulk.

Closes volkermauel/open-balena-ui#2.

### What you get

- **"Update Supervisor" action** on the device summary card (shows current version + pending target), in the device list bulk actions, and on fleets (devices grouped per device type, one dialog per type).
- **Version dialog**: newest-first catalog, current version marked, downgrades disabled, seeded/cached state indicated. Apply sets the target per device and reports per-device results (the API's downgrade rejection surfaces verbatim; bulk tolerates partial failure).
- **Seeding** (implicit on first use, idempotent): creates the `balena_os/<arch>-supervisor` app + services + image metadata rows **with the caller's JWT**, then mirrors the image bytes, then creates the release — crash-safe order that never exposes a release referencing un-mirrored images. Re-seeds reuse existing rows.
- **Registry mirroring**: byte-identical copy by digest from `registry2.balena-cloud.com` into the instance's own registry (`OPEN_BALENA_REGISTRY_URL` or derived from the API host) — manifests PUT as raw bytes with source Content-Type so balenaCloud `content_hash` stays valid; lists/indices recurse children-first; existing blobs/manifests HEAD-skipped; everything streamed, digests verified after upload.
- 4 routes (`/supervisor-releases/{versions,status,seed,update}`), all behind the existing JWT auth + dos protection.

### New environment variables

| Variable | Purpose |
| --- | --- |
| `BALENACLOUD_TOKEN` | balenaCloud API/registry JWT used **only** to pull supervisor images for mirroring; without it the version list still works (read-only, no mirroring) |
| `OPEN_BALENA_REGISTRY_URL` | Target registry override (default: derived from `REACT_APP_OPEN_BALENA_API_URL` by swapping the leftmost host label to `registry2`) |

### Security notes

- Caller JWT is forwarded **only** to the instance API/registry; `BALENACLOUD_TOKEN` only to balenaCloud — never logged, never in error bodies. Registry push tokens are cached per caller and expire with their JWT `exp`.
- Every registry digest (including ones parsed out of manifest JSON) is validated against `^sha256:[a-f0-9]{64}$` before entering a URL; OData tokens from user input are allow-list checked.

### Tests & docs

28 unit tests (`node:test`, fetch fully mocked, no network): mirror flow with fixtures, digest hostile-input rejection, catalog merge/dedupe ordering, seed planner, aggregate results. OpenSpec change proposal in `openspec/changes/add-supervisor-version-management/`. Real-device acceptance (supervisor actually applying a new target) is left to instance operators — documented in the design's risks.

## How to test

1. `npm ci && npm test && npm run build`
2. Boot with `OPEN_BALENA_S3_*` set (pre-existing server requirement); all 4 routes answer 401 unauthenticated.
3. With `BALENACLOUD_TOKEN` set: open a device → Update Supervisor → pick a newer version → Apply; first apply takes minutes (image copy), then the device's target update is a fast PATCH.
